### PR TITLE
Added a keepAlive setting

### DIFF
--- a/CloudStructures/Redis/RedisGroupConfigurationSection.cs
+++ b/CloudStructures/Redis/RedisGroupConfigurationSection.cs
@@ -105,6 +105,7 @@ namespace CloudStructures.Redis
                 x.AllowAdmin,
                 x.SyncTimeout,
                 x.Db,
+                x.KeepAlive,
                 x.ValueConverter,
                 x.CommandTracer));
             return new RedisGroup(Name, settings.ToArray(), ServerSelector);
@@ -136,6 +137,9 @@ namespace CloudStructures.Redis
 
         [ConfigurationProperty("db", DefaultValue = 0)]
         public int Db { get { return (int)base["db"]; } }
+
+        [ConfigurationProperty("keepAlive", DefaultValue = -1)]
+        public int KeepAlive { get { return (int)base["keepAlive"]; } }
 
         [ConfigurationProperty("valueConverter"), TypeConverter(typeof(TypeNameConverter))]
         public IRedisValueConverter ValueConverter

--- a/CloudStructures/Redis/RedisSettings.cs
+++ b/CloudStructures/Redis/RedisSettings.cs
@@ -16,6 +16,7 @@ namespace CloudStructures.Redis
         public bool AllowAdmin { get; private set; }
         public int SyncTimeout { get; private set; }
         public int Db { get; private set; }
+        public int KeepAlive { get; private set; }
         public IRedisValueConverter ValueConverter { get; private set; }
         public Func<ICommandTracer> CommandTracerFactory { get; private set; }
 
@@ -24,7 +25,7 @@ namespace CloudStructures.Redis
         public Action<RedisConnectionBase, EventArgs> OnConnectionClosed { private get; set; }
         public Action<RedisConnectionBase, ErrorEventArgs> OnConnectionShutdown { private get; set; }
 
-        public RedisSettings(string host, int port = 6379, int ioTimeout = -1, string password = null, int maxUnsent = 2147483647, bool allowAdmin = false, int syncTimeout = 10000, int db = 0, IRedisValueConverter converter = null, Func<ICommandTracer> tracerFactory = null)
+        public RedisSettings(string host, int port = 6379, int ioTimeout = -1, string password = null, int maxUnsent = 2147483647, bool allowAdmin = false, int syncTimeout = 10000, int db = 0, int keepAlive = -1, IRedisValueConverter converter = null, Func<ICommandTracer> tracerFactory = null)
         {
             this.Host = host;
             this.Port = port;
@@ -34,6 +35,7 @@ namespace CloudStructures.Redis
             this.AllowAdmin = allowAdmin;
             this.SyncTimeout = syncTimeout;
             this.Db = db;
+            this.KeepAlive = keepAlive;
             this.ValueConverter = converter ?? new JsonRedisValueConverter();
             this.CommandTracerFactory = tracerFactory;
         }
@@ -54,6 +56,7 @@ namespace CloudStructures.Redis
                     || ((connection.State != RedisConnectionBase.ConnectionState.Open) && (connection.State != RedisConnectionBase.ConnectionState.Opening)))
                     {
                         connection = new RedisConnection(Host, Port, IoTimeout, Password, MaxUnsent, AllowAdmin, SyncTimeout);
+                        connection.SetKeepAlive(KeepAlive);
 
                         // attach events
                         connection.Error += connection_Error;


### PR DESCRIPTION
- for config command restricted servers (etc. ElastiCache)
  http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ClientConfig.html

BookSleeve/RedisConnection
https://code.google.com/p/booksleeve/source/browse/BookSleeve/RedisConnection.cs

``` csharp
        /// <summary>
        /// Configures an automatic keep-alive PING at a pre-determined interval; this is especially
        /// useful if CONFIG GET is not available.
        /// </summary>
        public void SetKeepAlive(int seconds)
        {
            keepAliveSeconds = seconds;
            StopKeepAlive();
            if (seconds > 0)
            {
                Trace("keep-alive", "set to {0} seconds", seconds);
                timer = new System.Timers.Timer(seconds * 500); // check twice in the interval; Tick will decide which (if either) to use
                timer.Elapsed += (tick ?? (tick = Tick));
                timer.Start();
            }
        }
```

If keepAlive not set, call to config command.
but ElastiCache is restricted.

``` csharp
        /// <summary>
        /// Called during connection init, but after the AUTH is sent (if needed)
        /// </summary>
        protected override bool OnInitConnection()
        {
            var result = base.OnInitConnection();

            if (keepAliveSeconds < 0) // not known
            {
                var options = GetConfigImpl("timeout", true);
                options.ContinueWith(x =>
                {
```

redis setting for test (redis.conf)

```
rename-command CONFIG b840fc02d524045429941cc15f59e41cb7be6c52
 or
rename-command CONFIG ""
```
