### PR TITLE
fix compilation error in CloudStructures.Rx and remove BookSleeve deps

### DIFF
--- a/CloudStructures.Rx/CloudStructures.Rx.csproj
+++ b/CloudStructures.Rx/CloudStructures.Rx.csproj
@@ -35,10 +35,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BookSleeve, Version=1.3.38.0, Culture=neutral, PublicKeyToken=9056fda458ff61cf, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\BookSleeve.1.3.39\lib\BookSleeve.dll</HintPath>
-    </Reference>
     <Reference Include="Jil, Version=2.10.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Jil.2.10.0\lib\net45\Jil.dll</HintPath>
       <Private>True</Private>

--- a/CloudStructures.Rx/packages.config
+++ b/CloudStructures.Rx/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BookSleeve" version="1.3.39" targetFramework="net45" userInstalled="true" />
   <package id="Jil" version="2.10.0" targetFramework="net45" userInstalled="true" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net45" userInstalled="true" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net45" userInstalled="true" />


### PR DESCRIPTION
This PR fixes the errors because of api changed from BookSleeve to StackExchange.Redis and CloudStructures.IRedisValueConverter.