### PR TITLE
Splits DefaultExpiry from IRedisStructure

### DIFF
--- a/src/CloudStructures/Structures/IRedisStructure.cs
+++ b/src/CloudStructures/Structures/IRedisStructure.cs
@@ -103,7 +103,7 @@ namespace CloudStructures.Structures
         /// SETEX  : http://redis.io/commands/setex
         /// PSETEX : http://redis.io/commands/psetex
         /// </summary>
-        public static Task<bool> Expire<T>(this T redis, TimeSpan expiry, CommandFlags flags = CommandFlags.None)
+        public static Task<bool> Expire<T>(this T redis, TimeSpan? expiry, CommandFlags flags = CommandFlags.None)
             where T : IRedisStructure
             => redis.Connection.Database.KeyExpireAsync(redis.Key, expiry, flags);
 

--- a/src/CloudStructures/Structures/IRedisStructure.cs
+++ b/src/CloudStructures/Structures/IRedisStructure.cs
@@ -23,8 +23,17 @@ namespace CloudStructures.Structures
         /// Gets key.
         /// </summary>
         RedisKey Key { get; }
+        #endregion
+    }
 
 
+
+    /// <summary>
+    /// Represents a interface for Redis data structure with default expiration time.
+    /// </summary>
+    public interface IRedisStructureWithExpiry : IRedisStructure
+    {
+        #region Properties
         /// <summary>
         /// Gets default expiration time.
         /// </summary>
@@ -35,7 +44,7 @@ namespace CloudStructures.Structures
 
 
     /// <summary>
-    /// Provides extension methods for <see cref="IRedisStructure"/>.
+    /// Provides extension methods for <see cref="IRedisStructure"/> and <seealso cref="IRedisStructureWithExpiry"/>.
     /// </summary>
     public static class RedisStructureExtensions
     {

--- a/src/CloudStructures/Structures/RedisBit.cs
+++ b/src/CloudStructures/Structures/RedisBit.cs
@@ -11,9 +11,9 @@ namespace CloudStructures.Structures
     /// <summary>
     /// Provides bit related commands.
     /// </summary>
-    public readonly struct RedisBit : IRedisStructure
+    public readonly struct RedisBit : IRedisStructureWithExpiry
     {
-        #region IRedisStructure implementations
+        #region IRedisStructureWithExpiry implementations
         /// <summary>
         /// Gets connection.
         /// </summary>

--- a/src/CloudStructures/Structures/RedisDictionary.cs
+++ b/src/CloudStructures/Structures/RedisDictionary.cs
@@ -14,9 +14,9 @@ namespace CloudStructures.Structures
     /// </summary>
     /// <typeparam name="TKey">Key type</typeparam>
     /// <typeparam name="TValue">Value type</typeparam>
-    public readonly struct RedisDictionary<TKey, TValue> : IRedisStructure
+    public readonly struct RedisDictionary<TKey, TValue> : IRedisStructureWithExpiry
     {
-        #region IRedisStructure implementations
+        #region IRedisStructureWithExpiry implementations
         /// <summary>
         /// Gets connection.
         /// </summary>

--- a/src/CloudStructures/Structures/RedisGeo.cs
+++ b/src/CloudStructures/Structures/RedisGeo.cs
@@ -14,9 +14,9 @@ namespace CloudStructures.Structures
     /// Provides geometry related commands.
     /// </summary>
     /// <typeparam name="T">Data type</typeparam>
-    public readonly struct RedisGeo<T> : IRedisStructure
+    public readonly struct RedisGeo<T> : IRedisStructureWithExpiry
     {
-        #region IRedisStructure implementations
+        #region IRedisStructureWithExpiry implementations
         /// <summary>
         /// Gets connection.
         /// </summary>

--- a/src/CloudStructures/Structures/RedisHashSet.cs
+++ b/src/CloudStructures/Structures/RedisHashSet.cs
@@ -14,9 +14,9 @@ namespace CloudStructures.Structures
     /// Like RedisDictionary&lt;TKey, bool&gt;.
     /// </summary>
     /// <typeparam name="T">Data type</typeparam>
-    public readonly struct RedisHashSet<T> : IRedisStructure
+    public readonly struct RedisHashSet<T> : IRedisStructureWithExpiry
     {
-        #region IRedisStructure implementations
+        #region IRedisStructureWithExpiry implementations
         /// <summary>
         /// Gets connection.
         /// </summary>

--- a/src/CloudStructures/Structures/RedisHyperLogLog.cs
+++ b/src/CloudStructures/Structures/RedisHyperLogLog.cs
@@ -13,9 +13,9 @@ namespace CloudStructures.Structures
     /// Provides HyperLogLog related commands.
     /// </summary>
     /// <typeparam name="T">Data type</typeparam>
-    public readonly struct RedisHyperLogLog<T> : IRedisStructure
+    public readonly struct RedisHyperLogLog<T> : IRedisStructureWithExpiry
     {
-        #region IRedisStructure implementations
+        #region IRedisStructureWithExpiry implementations
         /// <summary>
         /// Gets connection.
         /// </summary>

--- a/src/CloudStructures/Structures/RedisList.cs
+++ b/src/CloudStructures/Structures/RedisList.cs
@@ -13,9 +13,9 @@ namespace CloudStructures.Structures
     /// Provides list related commands.
     /// </summary>
     /// <typeparam name="T">Data type</typeparam>
-    public readonly struct RedisList<T> : IRedisStructure
+    public readonly struct RedisList<T> : IRedisStructureWithExpiry
     {
-        #region IRedisStructure implementations
+        #region IRedisStructureWithExpiry implementations
         /// <summary>
         /// Gets connection.
         /// </summary>

--- a/src/CloudStructures/Structures/RedisLock.cs
+++ b/src/CloudStructures/Structures/RedisLock.cs
@@ -23,12 +23,6 @@ namespace CloudStructures.Structures
         /// Gets key.
         /// </summary>
         public RedisKey Key { get; }
-
-
-        /// <summary>
-        /// Gets default expiration time.
-        /// </summary>
-        public TimeSpan? DefaultExpiry { get; }
         #endregion
 
 
@@ -42,7 +36,6 @@ namespace CloudStructures.Structures
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this.Key = key;
-            this.DefaultExpiry = default;
         }
         #endregion
 

--- a/src/CloudStructures/Structures/RedisLock.cs
+++ b/src/CloudStructures/Structures/RedisLock.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Threading.Tasks;
+using StackExchange.Redis;
+
+
+
+namespace CloudStructures.Structures
+{
+    /// <summary>
+    /// Provides lock related commands.
+    /// </summary>
+    /// <typeparam name="T">Data type</typeparam>
+    public readonly struct RedisLock<T> : IRedisStructure
+    {
+        #region IRedisStructure implementations
+        /// <summary>
+        /// Gets connection.
+        /// </summary>
+        public RedisConnection Connection { get; }
+
+
+        /// <summary>
+        /// Gets key.
+        /// </summary>
+        public RedisKey Key { get; }
+
+
+        /// <summary>
+        /// Gets default expiration time.
+        /// </summary>
+        public TimeSpan? DefaultExpiry { get; }
+        #endregion
+
+
+        #region Constructors
+        /// <summary>
+        /// Creates instance.
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <param name="key"></param>
+        public RedisLock(RedisConnection connection, RedisKey key)
+        {
+            this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
+            this.Key = key;
+            this.DefaultExpiry = default;
+        }
+        #endregion
+
+
+        #region Commands
+        //- [x] LockExtendAsync
+        //- [x] LockQueryAsync
+        //- [x] LockReleaseAsync
+        //- [x] LockTakeAsync
+
+
+        /// <summary>
+        /// Extends a lock, if the token value is correct.
+        /// </summary>
+        public Task<bool> Extend(T value, TimeSpan expiry, CommandFlags flags = CommandFlags.None)
+        {
+            var serialized = this.Connection.Converter.Serialize(value);
+            return this.Connection.Database.LockExtendAsync(this.Key, serialized, expiry, flags);
+        }
+
+
+        /// <summary>
+        /// Queries the token held against a lock.
+        /// </summary>
+        public async Task<RedisResult<T>> Query(CommandFlags flags = CommandFlags.None)
+        {
+            var value = await this.Connection.Database.LockQueryAsync(this.Key, flags).ConfigureAwait(false);
+            return value.ToResult<T>(this.Connection.Converter);
+        }
+
+
+        /// <summary>
+        /// Releases a lock, if the token value is correct.
+        /// </summary>
+        public Task<bool> Release(T value, CommandFlags flags = CommandFlags.None)
+        {
+            var serialized = this.Connection.Converter.Serialize(value);
+            return this.Connection.Database.LockReleaseAsync(this.Key, serialized, flags);
+        }
+
+
+        /// <summary>
+        /// Takes a lock (specifying a token value) if it is not already taken.
+        /// </summary>
+        public Task<bool> Take(T value, TimeSpan expiry, CommandFlags flags = CommandFlags.None)
+        {
+            var serialized = this.Connection.Converter.Serialize(value);
+            return this.Connection.Database.LockTakeAsync(this.Key, serialized, expiry, flags);
+        }
+        #endregion
+    }
+}

--- a/src/CloudStructures/Structures/RedisLua.cs
+++ b/src/CloudStructures/Structures/RedisLua.cs
@@ -23,12 +23,6 @@ namespace CloudStructures.Structures
         /// Gets key.
         /// </summary>
         public RedisKey Key { get; }
-
-
-        /// <summary>
-        /// Gets default expiration time.
-        /// </summary>
-        public TimeSpan? DefaultExpiry { get; }
         #endregion
 
 
@@ -38,12 +32,10 @@ namespace CloudStructures.Structures
         /// </summary>
         /// <param name="connection"></param>
         /// <param name="key"></param>
-        /// <param name="defaultExpiry"></param>
-        public RedisLua(RedisConnection connection, RedisKey key, TimeSpan? defaultExpiry)
+        public RedisLua(RedisConnection connection, RedisKey key)
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this.Key = key;
-            this.DefaultExpiry = defaultExpiry;
         }
         #endregion
 

--- a/src/CloudStructures/Structures/RedisSet.cs
+++ b/src/CloudStructures/Structures/RedisSet.cs
@@ -13,9 +13,9 @@ namespace CloudStructures.Structures
     /// Provides set related commands.
     /// </summary>
     /// <typeparam name="T">Data type</typeparam>
-    public readonly struct RedisSet<T> : IRedisStructure
+    public readonly struct RedisSet<T> : IRedisStructureWithExpiry
     {
-        #region IRedisStructure implementations
+        #region IRedisStructureWithExpiry implementations
         /// <summary>
         /// Gets connection.
         /// </summary>

--- a/src/CloudStructures/Structures/RedisSortedSet.cs
+++ b/src/CloudStructures/Structures/RedisSortedSet.cs
@@ -14,9 +14,9 @@ namespace CloudStructures.Structures
     /// Provides sorted set related commands.
     /// </summary>
     /// <typeparam name="T">Data type</typeparam>
-    public readonly struct RedisSortedSet<T> : IRedisStructure
+    public readonly struct RedisSortedSet<T> : IRedisStructureWithExpiry
     {
-        #region IRedisStructure implementations
+        #region IRedisStructureWithExpiry implementations
         /// <summary>
         /// Gets connection.
         /// </summary>

--- a/src/CloudStructures/Structures/RedisString.cs
+++ b/src/CloudStructures/Structures/RedisString.cs
@@ -11,9 +11,9 @@ namespace CloudStructures.Structures
     /// Provides string related commands.
     /// </summary>
     /// <typeparam name="T">Data type</typeparam>
-    public readonly struct RedisString<T> : IRedisStructure
+    public readonly struct RedisString<T> : IRedisStructureWithExpiry
     {
-        #region IRedisStructure implementations
+        #region IRedisStructureWithExpiry implementations
         /// <summary>
         /// Gets connection.
         /// </summary>


### PR DESCRIPTION
# Motivation
Some Redis structures (ex. `RedisLua` / `RedisLock`) doesn't need `DefaultExpiry` property. So I want to split `DefaultExpiry` from `IRedisStructure` and establish `IRedisStructureWithExpiry`.


# Changes
- Establishes `IRedisStructureWithExpiry`
- Removes `DefaultExpiry` property from `RedisLua` and `RedisLock`
- Micro bug fix


# Attention
If ok, should merge after #19. This PR includes #19. 