### PR TITLE
Changes naming policy of async method

### DIFF
--- a/src/CloudStructures/Internals/RedisOperationHelpers.cs
+++ b/src/CloudStructures/Internals/RedisOperationHelpers.cs
@@ -22,7 +22,7 @@ namespace CloudStructures.Internals
         /// <param name="expiry"></param>
         /// <param name="flags"></param>
         /// <returns></returns>
-        public static async Task ExecuteWithExpiry<TRedis, TArgs>(this TRedis structure, Func<IDatabaseAsync, TArgs, Task> command, TArgs args, TimeSpan? expiry, CommandFlags flags)
+        public static async Task ExecuteWithExpiryAsync<TRedis, TArgs>(this TRedis structure, Func<IDatabaseAsync, TArgs, Task> command, TArgs args, TimeSpan? expiry, CommandFlags flags)
             where TRedis : IRedisStructure
         {
             if (structure == null) throw new ArgumentNullException(nameof(structure));
@@ -57,7 +57,7 @@ namespace CloudStructures.Internals
         /// <param name="expiry"></param>
         /// <param name="flags"></param>
         /// <returns></returns>
-        public static async Task<TResult> ExecuteWithExpiry<TRedis, TArgs, TResult>(this TRedis structure, Func<IDatabaseAsync, TArgs, Task<TResult>> command, TArgs args, TimeSpan? expiry, CommandFlags flags)
+        public static async Task<TResult> ExecuteWithExpiryAsync<TRedis, TArgs, TResult>(this TRedis structure, Func<IDatabaseAsync, TArgs, Task<TResult>> command, TArgs args, TimeSpan? expiry, CommandFlags flags)
             where TRedis : IRedisStructure
         {
             if (structure == null) throw new ArgumentNullException(nameof(structure));

--- a/src/CloudStructures/Structures/IRedisStructure.cs
+++ b/src/CloudStructures/Structures/IRedisStructure.cs
@@ -78,7 +78,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// DEL : http://redis.io/commands/del
         /// </summary>
-        public static Task<bool> Delete<T>(this T redis, CommandFlags flags = CommandFlags.None)
+        public static Task<bool> DeleteAsync<T>(this T redis, CommandFlags flags = CommandFlags.None)
             where T : IRedisStructure
             => redis.Connection.Database.KeyDeleteAsync(redis.Key, flags);
 
@@ -86,7 +86,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// DUMP : https://redis.io/commands/dump
         /// </summary>
-        public static Task<byte[]> Dump<T>(this T redis, CommandFlags flags = CommandFlags.None)
+        public static Task<byte[]> DumpAsync<T>(this T redis, CommandFlags flags = CommandFlags.None)
             where T : IRedisStructure
             => redis.Connection.Database.KeyDumpAsync(redis.Key, flags);
 
@@ -94,7 +94,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// EXISTS : http://redis.io/commands/exists
         /// </summary>
-        public static Task<bool> Exists<T>(this T redis, CommandFlags flags = CommandFlags.None)
+        public static Task<bool> ExistsAsync<T>(this T redis, CommandFlags flags = CommandFlags.None)
             where T : IRedisStructure
             => redis.Connection.Database.KeyExistsAsync(redis.Key, flags);
 
@@ -103,7 +103,7 @@ namespace CloudStructures.Structures
         /// SETEX  : http://redis.io/commands/setex
         /// PSETEX : http://redis.io/commands/psetex
         /// </summary>
-        public static Task<bool> Expire<T>(this T redis, TimeSpan? expiry, CommandFlags flags = CommandFlags.None)
+        public static Task<bool> ExpireAsync<T>(this T redis, TimeSpan? expiry, CommandFlags flags = CommandFlags.None)
             where T : IRedisStructure
             => redis.Connection.Database.KeyExpireAsync(redis.Key, expiry, flags);
 
@@ -111,7 +111,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// MOVE : https://redis.io/commands/move
         /// </summary>
-        public static Task<bool> Move<T>(this T redis, int database, CommandFlags flags = CommandFlags.None)
+        public static Task<bool> MoveAsync<T>(this T redis, int database, CommandFlags flags = CommandFlags.None)
             where T : IRedisStructure
             => redis.Connection.Database.KeyMoveAsync(redis.Key, database, flags);
 
@@ -119,7 +119,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// MIGRATE : https://redis.io/commands/migrate
         /// </summary>
-        public static Task Migrate<T>(this T redis, EndPoint toServer, int toDatabase = 0, int timeoutMilliseconds = 0, MigrateOptions migrateOptions = MigrateOptions.None, CommandFlags flags = CommandFlags.None)
+        public static Task MigrateAsync<T>(this T redis, EndPoint toServer, int toDatabase = 0, int timeoutMilliseconds = 0, MigrateOptions migrateOptions = MigrateOptions.None, CommandFlags flags = CommandFlags.None)
             where T : IRedisStructure
             => redis.Connection.Database.KeyMigrateAsync(redis.Key, toServer, toDatabase, timeoutMilliseconds, migrateOptions, flags);
 
@@ -127,7 +127,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// PERSIST : https://redis.io/commands/persist
         /// </summary>
-        public static Task<bool> Persist<T>(this T redis, CommandFlags flags = CommandFlags.None)
+        public static Task<bool> PersistAsync<T>(this T redis, CommandFlags flags = CommandFlags.None)
             where T : IRedisStructure
             => redis.Connection.Database.KeyPersistAsync(redis.Key, flags);
 
@@ -135,7 +135,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// RENAME : https://redis.io/commands/rename
         /// </summary>
-        public static Task<bool> Rename<T>(this T redis, RedisKey newKey, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        public static Task<bool> RenameAsync<T>(this T redis, RedisKey newKey, When when = When.Always, CommandFlags flags = CommandFlags.None)
             where T : IRedisStructure
             => redis.Connection.Database.KeyRenameAsync(redis.Key, newKey, when, flags);
 
@@ -143,7 +143,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// TTL http://redis.io/commands/ttl
         /// </summary>
-        public static Task<TimeSpan?> TimeToLive<T>(this T redis, CommandFlags flags = CommandFlags.None)
+        public static Task<TimeSpan?> TimeToLiveAsync<T>(this T redis, CommandFlags flags = CommandFlags.None)
             where T : IRedisStructure
             => redis.Connection.Database.KeyTimeToLiveAsync(redis.Key, flags);
 
@@ -151,7 +151,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// TYPE : https://redis.io/commands/type
         /// </summary>
-        public static Task<RedisType> Type<T>(this T redis, CommandFlags flags = CommandFlags.None)
+        public static Task<RedisType> TypeAsync<T>(this T redis, CommandFlags flags = CommandFlags.None)
             where T : IRedisStructure
             => redis.Connection.Database.KeyTypeAsync(redis.Key, flags);
         #endregion

--- a/src/CloudStructures/Structures/RedisBit.cs
+++ b/src/CloudStructures/Structures/RedisBit.cs
@@ -60,14 +60,14 @@ namespace CloudStructures.Structures
         /// <summary>
         /// BITCOUNT : http://redis.io/commands/bitcount
         /// </summary>
-        public Task<long> Count(long start = 0, long end = -1, CommandFlags flags = CommandFlags.None)
+        public Task<long> CountAsync(long start = 0, long end = -1, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.StringBitCountAsync(this.Key, start, end, flags);
 
 
         /// <summary>
         /// BITOP : https://redis.io/commands/bitop
         /// </summary>
-        public Task<long> Operation(Bitwise operation, RedisBit first, RedisBit? second = null, CommandFlags flags = CommandFlags.None)
+        public Task<long> OperationAsync(Bitwise operation, RedisBit first, RedisBit? second = null, CommandFlags flags = CommandFlags.None)
         {
             var firstKey = first.Key;
             var secondKey = second?.Key ?? default; 
@@ -78,7 +78,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// BITOP : https://redis.io/commands/bitop
         /// </summary>
-        public Task<long> Operation(Bitwise operation, RedisBit[] bits, CommandFlags flags = CommandFlags.None)
+        public Task<long> OperationAsync(Bitwise operation, RedisBit[] bits, CommandFlags flags = CommandFlags.None)
         {
             if (bits == null) throw new ArgumentNullException(nameof(bits));
             if (bits.Length == 0) throw new ArgumentException("bits length is 0.");
@@ -91,24 +91,24 @@ namespace CloudStructures.Structures
         /// <summary>
         /// BITPOSITION : http://redis.io/commands/bitpos
         /// </summary>
-        public Task<long> Position(bool bit, long start = 0, long end = -1, CommandFlags flags = CommandFlags.None)
+        public Task<long> PositionAsync(bool bit, long start = 0, long end = -1, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.StringBitPositionAsync(this.Key, bit, start, end, flags);
 
 
         /// <summary>
         /// GETBIT : http://redis.io/commands/getbit
         /// </summary>
-        public Task<bool> Get(long offset, CommandFlags flags = CommandFlags.None)
+        public Task<bool> GetAsync(long offset, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.StringGetBitAsync(this.Key, offset, flags);
 
 
         /// <summary>
         /// SETBIT : http://redis.io/commands/setbit
         /// </summary>
-        public Task<bool> Set(long offset, bool bit, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<bool> SetAsync(long offset, bool bit, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.StringSetBitAsync(a.key, a.offset, a.bit, a.flags),
                 (key: this.Key, offset, bit, flags),

--- a/src/CloudStructures/Structures/RedisDictionary.cs
+++ b/src/CloudStructures/Structures/RedisDictionary.cs
@@ -68,11 +68,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// HINCRBY : https://redis.io/commands/hincrby
         /// </summary>
-        public Task<long> Decrement(TKey field, long value = 1, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<long> DecrementAsync(TKey field, long value = 1, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var hashField = this.Connection.Converter.Serialize(field);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.HashDecrementAsync(a.key, a.hashField, a.value, a.flags),
                 (key: this.Key, hashField, value, flags),
@@ -85,11 +85,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// HINCRBYFLOAT : https://redis.io/commands/hincrbyfloat
         /// </summary>
-        public Task Decrement(TKey field, double value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task DecrementAsync(TKey field, double value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var hashField = this.Connection.Converter.Serialize(field);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.HashDecrementAsync(a.key, a.hashField, a.value, a.flags),
                 (key: this.Key, hashField, value, flags),
@@ -102,7 +102,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// HDEL : https://redis.io/commands/hdel
         /// </summary>
-        public Task<bool> Delete(TKey field, CommandFlags flags = CommandFlags.None)
+        public Task<bool> DeleteAsync(TKey field, CommandFlags flags = CommandFlags.None)
         {
             var hashField = this.Connection.Converter.Serialize(field);
             return this.Connection.Database.HashDeleteAsync(this.Key, hashField, flags);
@@ -112,7 +112,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// HDEL : https://redis.io/commands/hdel
         /// </summary>
-        public Task<long> Delete(IEnumerable<TKey> fields, CommandFlags flags = CommandFlags.None)
+        public Task<long> DeleteAsync(IEnumerable<TKey> fields, CommandFlags flags = CommandFlags.None)
         {
             var hashFields = fields.Select(this.Connection.Converter.Serialize).ToArray();
             return this.Connection.Database.HashDeleteAsync(this.Key, hashFields, flags);
@@ -122,7 +122,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// HEXISTS : https://redis.io/commands/hexists
         /// </summary>
-        public Task<bool> Exists(TKey field, CommandFlags flags = CommandFlags.None)
+        public Task<bool> ExistsAsync(TKey field, CommandFlags flags = CommandFlags.None)
         {
             var hashField = this.Connection.Converter.Serialize(field);
             return this.Connection.Database.HashExistsAsync(this.Key, hashField, flags);
@@ -132,7 +132,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// HGETALL : https://redis.io/commands/hgetall
         /// </summary>
-        public async Task<Dictionary<TKey, TValue>> GetAll(IEqualityComparer<TKey> dictionaryEqualityComparer = null, CommandFlags flags = CommandFlags.None)
+        public async Task<Dictionary<TKey, TValue>> GetAllAsync(IEqualityComparer<TKey> dictionaryEqualityComparer = null, CommandFlags flags = CommandFlags.None)
         {
             var comparer = dictionaryEqualityComparer ?? EqualityComparer<TKey>.Default;
             var entries = await this.Connection.Database.HashGetAllAsync(this.Key, flags).ConfigureAwait(false);
@@ -150,7 +150,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// HGET : https://redis.io/commands/hget
         /// </summary>
-        public async Task<RedisResult<TValue>> Get(TKey field, CommandFlags flags = CommandFlags.None)
+        public async Task<RedisResult<TValue>> GetAsync(TKey field, CommandFlags flags = CommandFlags.None)
         {
             var hashField = this.Connection.Converter.Serialize(field);
             var value = await this.Connection.Database.HashGetAsync(this.Key, hashField, flags).ConfigureAwait(false);
@@ -161,7 +161,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// HMGET : https://redis.io/commands/hmget
         /// </summary>
-        public async Task<Dictionary<TKey, TValue>> Get(IEnumerable<TKey> fields, IEqualityComparer<TKey> dictionaryEqualityComparer = null, CommandFlags flags = CommandFlags.None)
+        public async Task<Dictionary<TKey, TValue>> GetAsync(IEnumerable<TKey> fields, IEqualityComparer<TKey> dictionaryEqualityComparer = null, CommandFlags flags = CommandFlags.None)
         {
             fields = fields.Materialize(false);
             var comparer = dictionaryEqualityComparer ?? EqualityComparer<TKey>.Default;
@@ -182,11 +182,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// HINCRBY : https://redis.io/commands/hincrby
         /// </summary>
-        public Task<long> Increment(TKey field, long value = 1, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<long> IncrementAsync(TKey field, long value = 1, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var hashField = this.Connection.Converter.Serialize(field);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.HashIncrementAsync(a.key, a.hashField, a.value, a.flags),
                 (key: this.Key, hashField, value, flags),
@@ -199,11 +199,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// HINCRBYFLOAT : https://redis.io/commands/hincrbyfloat
         /// </summary>
-        public Task Increment(TKey field, double value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task IncrementAsync(TKey field, double value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var hashField = this.Connection.Converter.Serialize(field);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.HashIncrementAsync(a.key, a.hashField, a.value, a.flags),
                 (key: this.Key, hashField, value, flags),
@@ -216,7 +216,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// HKEYS : https://redis.io/commands/hkeys
         /// </summary>
-        public async Task<TKey[]> Keys(CommandFlags flags = CommandFlags.None)
+        public async Task<TKey[]> KeysAsync(CommandFlags flags = CommandFlags.None)
         {
             var keys = await this.Connection.Database.HashKeysAsync(this.Key, flags).ConfigureAwait(false);
             return keys.Select(this.Connection.Converter, (x, c) => c.Deserialize<TKey>(x)).ToArray();
@@ -226,19 +226,19 @@ namespace CloudStructures.Structures
         /// <summary>
         /// HLEN : https://redis.io/commands/hlen
         /// </summary>
-        public Task<long> Length(CommandFlags flags = CommandFlags.None)
+        public Task<long> LengthAsync(CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.HashLengthAsync(this.Key, flags);
 
 
         /// <summary>
         /// HSET : https://redis.io/commands/hset
         /// </summary>
-        public Task<bool> Set(TKey field, TValue value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        public Task<bool> SetAsync(TKey field, TValue value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var f = this.Connection.Converter.Serialize(field);
             var v = this.Connection.Converter.Serialize(value);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.HashSetAsync(a.key, a.f, a.v, a.when, a.flags),
                 (key: this.Key, f, v, when, flags),
@@ -251,7 +251,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// HMSET : https://redis.io/commands/hmset
         /// </summary>
-        public Task Set(IEnumerable<KeyValuePair<TKey, TValue>> entries, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task SetAsync(IEnumerable<KeyValuePair<TKey, TValue>> entries, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var hashEntries
@@ -265,7 +265,7 @@ namespace CloudStructures.Structures
                 .ToArray();
             return (hashEntries.Length == 0)
                 ? Task.CompletedTask
-                : this.ExecuteWithExpiry
+                : this.ExecuteWithExpiryAsync
                 (
                     (db, a) => db.HashSetAsync(a.key, a.hashEntries, a.flags),
                     (key: this.Key, hashEntries, flags),
@@ -278,7 +278,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// HVALS : https://redis.io/commands/hvals
         /// </summary>
-        public async Task<TValue[]> Values(CommandFlags flags = CommandFlags.None)
+        public async Task<TValue[]> ValuesAsync(CommandFlags flags = CommandFlags.None)
         {
             var values = await this.Connection.Database.HashValuesAsync(this.Key, flags).ConfigureAwait(false);
             return values.Select(this.Connection.Converter, (x, c) => c.Deserialize<TValue>(x)).ToArray();
@@ -291,7 +291,7 @@ namespace CloudStructures.Structures
         /// HGET : https://redis.io/commands/hget
         /// HSET : https://redis.io/commands/hset
         /// </summary>
-        public async Task<TValue> GetOrSet(TKey field, Func<TKey, TValue> valueFactory, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public async Task<TValue> GetOrSetAsync(TKey field, Func<TKey, TValue> valueFactory, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             if (valueFactory == null)
                 throw new ArgumentNullException(nameof(valueFactory));
@@ -305,7 +305,7 @@ namespace CloudStructures.Structures
             else
             {
                 var newValue = valueFactory(field);
-                await this.Set(field, newValue, expiry, When.Always, flags).ConfigureAwait(false);
+                await this.SetAsync(field, newValue, expiry, When.Always, flags).ConfigureAwait(false);
                 return newValue;
             }
         }
@@ -315,7 +315,7 @@ namespace CloudStructures.Structures
         /// HGET : https://redis.io/commands/hget
         /// HSET : https://redis.io/commands/hset
         /// </summary>
-        public async Task<TValue> GetOrSet(TKey field, Func<TKey, Task<TValue>> valueFactory, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public async Task<TValue> GetOrSetAsync(TKey field, Func<TKey, Task<TValue>> valueFactory, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             if (valueFactory == null)
                 throw new ArgumentNullException(nameof(valueFactory));
@@ -329,7 +329,7 @@ namespace CloudStructures.Structures
             else
             {
                 var newValue = await valueFactory(field).ConfigureAwait(false);
-                await this.Set(field, newValue, expiry, When.Always, flags).ConfigureAwait(false);
+                await this.SetAsync(field, newValue, expiry, When.Always, flags).ConfigureAwait(false);
                 return newValue;
             }
         }
@@ -339,7 +339,7 @@ namespace CloudStructures.Structures
         /// HMGET : https://redis.io/commands/hmget
         /// HMSET : https://redis.io/commands/hmset
         /// </summary>
-        public async Task<Dictionary<TKey, TValue>> GetOrSet(IEnumerable<TKey> fields, Func<IEnumerable<TKey>, IEnumerable<KeyValuePair<TKey, TValue>>> valueFactory, TimeSpan? expiry = null, IEqualityComparer<TKey> dictionaryEqualityComparer = null, CommandFlags flags = CommandFlags.None)
+        public async Task<Dictionary<TKey, TValue>> GetOrSetAsync(IEnumerable<TKey> fields, Func<IEnumerable<TKey>, IEnumerable<KeyValuePair<TKey, TValue>>> valueFactory, TimeSpan? expiry = null, IEqualityComparer<TKey> dictionaryEqualityComparer = null, CommandFlags flags = CommandFlags.None)
         {
             if (valueFactory == null)
                 throw new ArgumentNullException(nameof(valueFactory));
@@ -368,7 +368,7 @@ namespace CloudStructures.Structures
             if (notCached.Count > 0)
             {
                 var loaded = valueFactory(notCached).Materialize();
-                await this.Set(loaded, expiry, flags).ConfigureAwait(false);
+                await this.SetAsync(loaded, expiry, flags).ConfigureAwait(false);
                 foreach (var x in loaded)
                     cached[x.Key] = x.Value;
             }
@@ -380,7 +380,7 @@ namespace CloudStructures.Structures
         /// HMGET : https://redis.io/commands/hmget
         /// HMSET : https://redis.io/commands/hmset
         /// </summary>
-        public async Task<Dictionary<TKey, TValue>> GetOrSet(IEnumerable<TKey> fields, Func<IEnumerable<TKey>, Task<IEnumerable<KeyValuePair<TKey, TValue>>>> valueFactory, TimeSpan? expiry = null, IEqualityComparer<TKey> dictionaryEqualityComparer = null, CommandFlags flags = CommandFlags.None)
+        public async Task<Dictionary<TKey, TValue>> GetOrSetAsync(IEnumerable<TKey> fields, Func<IEnumerable<TKey>, Task<IEnumerable<KeyValuePair<TKey, TValue>>>> valueFactory, TimeSpan? expiry = null, IEqualityComparer<TKey> dictionaryEqualityComparer = null, CommandFlags flags = CommandFlags.None)
         {
             if (valueFactory == null)
                 throw new ArgumentNullException(nameof(valueFactory));
@@ -409,7 +409,7 @@ namespace CloudStructures.Structures
             if (notCached.Count > 0)
             {
                 var loaded = (await valueFactory(notCached).ConfigureAwait(false)).Materialize();
-                await this.Set(loaded, expiry, flags).ConfigureAwait(false);
+                await this.SetAsync(loaded, expiry, flags).ConfigureAwait(false);
                 foreach (var x in loaded)
                     cached[x.Key] = x.Value;
             }

--- a/src/CloudStructures/Structures/RedisGeo.cs
+++ b/src/CloudStructures/Structures/RedisGeo.cs
@@ -160,7 +160,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// GEORADIUS : https://redis.io/commands/georadius
         /// </summary>
-        public async Task<RedisGeoRadiusResult<T>[]> RadiusAsync(RedisKey key, double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        public async Task<RedisGeoRadiusResult<T>[]> RadiusAsync(double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
         {
             var results = await this.Connection.Database.GeoRadiusAsync(this.Key, longitude, latitude, radius, unit, count, order, options, flags).ConfigureAwait(false);
             return results.Select(this.Connection.Converter, (x, c) => x.ToGenerics<T>(c)).ToArray();

--- a/src/CloudStructures/Structures/RedisGeo.cs
+++ b/src/CloudStructures/Structures/RedisGeo.cs
@@ -64,11 +64,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// GEOADD : https://redis.io/commands/geoadd
         /// </summary>
-        public Task<bool> Add(RedisGeoEntry<T> value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<bool> AddAsync(RedisGeoEntry<T> value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var entry = value.ToNonGenerics(this.Connection.Converter);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.GeoAddAsync(a.key, a.entry, a.flags),
                 (key: this.Key, entry, flags),
@@ -81,11 +81,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// GEOADD : https://redis.io/commands/geoadd
         /// </summary>
-        public Task<long> Add(IEnumerable<RedisGeoEntry<T>> values, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<long> AddAsync(IEnumerable<RedisGeoEntry<T>> values, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var entries = values.Select(this.Connection.Converter, (x, c) => x.ToNonGenerics(c)).ToArray();
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.GeoAddAsync(a.key, a.entries, a.flags),
                 (key: this.Key, entries, flags),
@@ -98,18 +98,18 @@ namespace CloudStructures.Structures
         /// <summary>
         /// GEOADD : https://redis.io/commands/geoadd
         /// </summary>
-        public Task<bool> Add(double longitude, double latitude, T member, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<bool> AddAsync(double longitude, double latitude, T member, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var entry = new RedisGeoEntry<T>(longitude, latitude, member);
-            return this.Add(entry, expiry, flags);
+            return this.AddAsync(entry, expiry, flags);
         }
 
 
         /// <summary>
         /// GEODIST : https://redis.io/commands/geodist
         /// </summary>
-        public Task<double?> Distance(T member1, T member2, GeoUnit unit = GeoUnit.Meters, CommandFlags flags = CommandFlags.None)
+        public Task<double?> DistanceAsync(T member1, T member2, GeoUnit unit = GeoUnit.Meters, CommandFlags flags = CommandFlags.None)
         {
             var value1 = this.Connection.Converter.Serialize(member1);
             var value2 = this.Connection.Converter.Serialize(member2);
@@ -120,7 +120,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// GEOHASH : https://redis.io/commands/geohash
         /// </summary>
-        public Task<string> Hash(T member, CommandFlags flags = CommandFlags.None)
+        public Task<string> HashAsync(T member, CommandFlags flags = CommandFlags.None)
         {
             var value = this.Connection.Converter.Serialize(member);
             return this.Connection.Database.GeoHashAsync(this.Key, value, flags);
@@ -130,7 +130,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// GEOHASH : https://redis.io/commands/geohash
         /// </summary>
-        public Task<string[]> Hash(IEnumerable<T> members, CommandFlags flags = CommandFlags.None)
+        public Task<string[]> HashAsync(IEnumerable<T> members, CommandFlags flags = CommandFlags.None)
         {
             var values = members.Select(this.Connection.Converter.Serialize).ToArray();
             return this.Connection.Database.GeoHashAsync(this.Key, values, flags);
@@ -140,7 +140,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// GEOPOS : https://redis.io/commands/geopos
         /// </summary>
-        public Task<GeoPosition?> Position(T member, CommandFlags flags = CommandFlags.None)
+        public Task<GeoPosition?> PositionAsync(T member, CommandFlags flags = CommandFlags.None)
         {
             var value = this.Connection.Converter.Serialize(member);
             return this.Connection.Database.GeoPositionAsync(this.Key, value, flags);
@@ -150,7 +150,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// GEOPOS  https://redis.io/commands/geopos
         /// </summary>
-        public Task<GeoPosition?[]> Position(IEnumerable<T> members, CommandFlags flags = CommandFlags.None)
+        public Task<GeoPosition?[]> PositionAsync(IEnumerable<T> members, CommandFlags flags = CommandFlags.None)
         {
             var values = members.Select(this.Connection.Converter.Serialize).ToArray();
             return this.Connection.Database.GeoPositionAsync(this.Key, values, flags);
@@ -160,7 +160,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// GEORADIUS : https://redis.io/commands/georadius
         /// </summary>
-        public async Task<RedisGeoRadiusResult<T>[]> Radius(RedisKey key, double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        public async Task<RedisGeoRadiusResult<T>[]> RadiusAsync(RedisKey key, double longitude, double latitude, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
         {
             var results = await this.Connection.Database.GeoRadiusAsync(this.Key, longitude, latitude, radius, unit, count, order, options, flags).ConfigureAwait(false);
             return results.Select(this.Connection.Converter, (x, c) => x.ToGenerics<T>(c)).ToArray();
@@ -170,7 +170,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// GEORADIUSBYMEMBER : https://redis.io/commands/georadiusbymember
         /// </summary>
-        public async Task<RedisGeoRadiusResult<T>[]> Radius(T member, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
+        public async Task<RedisGeoRadiusResult<T>[]> RadiusAsync(T member, double radius, GeoUnit unit = GeoUnit.Meters, int count = -1, Order? order = null, GeoRadiusOptions options = GeoRadiusOptions.Default, CommandFlags flags = CommandFlags.None)
         {
             var value = this.Connection.Converter.Serialize(member);
             var results = await this.Connection.Database.GeoRadiusAsync(this.Key, value, radius, unit, count, order, options, flags).ConfigureAwait(false);
@@ -182,7 +182,7 @@ namespace CloudStructures.Structures
         /// ZREM : https://redis.io/commands/zrem
         /// </summary>
         /// <remarks>There is no GEODEL command.</remarks>
-        public Task<bool> Remove(T member, CommandFlags flags = CommandFlags.None)
+        public Task<bool> RemoveAsync(T member, CommandFlags flags = CommandFlags.None)
         {
             var value = this.Connection.Converter.Serialize(member);
             return this.Connection.Database.GeoRemoveAsync(this.Key, value, flags);

--- a/src/CloudStructures/Structures/RedisHashSet.cs
+++ b/src/CloudStructures/Structures/RedisHashSet.cs
@@ -56,7 +56,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// Deletes specified element.
         /// </summary>
-        public Task<bool> Delete(T value, CommandFlags flags = CommandFlags.None)
+        public Task<bool> DeleteAsync(T value, CommandFlags flags = CommandFlags.None)
         {
             // HDEL
             // https://redis.io/commands/hdel
@@ -69,7 +69,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// Deletes specified elements.
         /// </summary>
-        public Task<long> Delete(IEnumerable<T> values, CommandFlags flags = CommandFlags.None)
+        public Task<long> DeleteAsync(IEnumerable<T> values, CommandFlags flags = CommandFlags.None)
         {
             // HDEL
             // https://redis.io/commands/hdel
@@ -82,7 +82,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// Checks specified element existence.
         /// </summary>
-        public async Task<bool> Contains(T value, CommandFlags flags = CommandFlags.None)
+        public async Task<bool> ContainsAsync(T value, CommandFlags flags = CommandFlags.None)
         {
             // HGET
             // https://redis.io/commands/hget
@@ -96,7 +96,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// Checks specified elements existence.
         /// </summary>
-        public async Task<Dictionary<T, bool>> Contains(IEnumerable<T> values, CommandFlags flags = CommandFlags.None)
+        public async Task<Dictionary<T, bool>> ContainsAsync(IEnumerable<T> values, CommandFlags flags = CommandFlags.None)
         {
             // HMGET
             // https://redis.io/commands/hmget
@@ -113,7 +113,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// Gets all elements.
         /// </summary>
-        public async Task<T[]> Values(CommandFlags flags = CommandFlags.None)
+        public async Task<T[]> ValuesAsync(CommandFlags flags = CommandFlags.None)
         {
             // HKEYS で OK
             // https://redis.io/commands/hkeys
@@ -126,14 +126,14 @@ namespace CloudStructures.Structures
         /// <summary>
         /// Gets length.
         /// </summary>
-        public Task<long> Length(CommandFlags flags = CommandFlags.None)
+        public Task<long> LengthAsync(CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.HashLengthAsync(this.Key, flags);  // HLEN https://redis.io/commands/hlen
 
 
         /// <summary>
         /// Adds value.
         /// </summary>
-        public Task<bool> Add(T value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        public Task<bool> AddAsync(T value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
             // HSET
             // https://redis.io/commands/hset
@@ -141,7 +141,7 @@ namespace CloudStructures.Structures
             expiry = expiry ?? this.DefaultExpiry;
             var f = this.Connection.Converter.Serialize(value);
             var v = this.Connection.Converter.Serialize(true);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.HashSetAsync(a.key, a.f, a.v, a.when, a.flags),
                 (key: this.Key, f, v, when, flags),
@@ -154,7 +154,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// Adds values.
         /// </summary>
-        public Task Add(IEnumerable<T> values, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task AddAsync(IEnumerable<T> values, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             // HMSET
             // https://redis.io/commands/hmset
@@ -169,7 +169,7 @@ namespace CloudStructures.Structures
                     return new HashEntry(f, v);
                 })
                 .ToArray();
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.HashSetAsync(a.key, a.hashEntries, a.flags),
                 (key: this.Key, hashEntries, flags),

--- a/src/CloudStructures/Structures/RedisHyperLogLog.cs
+++ b/src/CloudStructures/Structures/RedisHyperLogLog.cs
@@ -60,11 +60,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// PFADD : http://redis.io/commands/pfadd
         /// </summary>
-        public Task<bool> Add(T value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<bool> AddAsync(T value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialized = this.Connection.Converter.Serialize(value);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.HyperLogLogAddAsync(a.key, a.serialized, a.flags),
                 (key: this.Key, serialized, flags),
@@ -77,11 +77,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// PFADD : http://redis.io/commands/pfadd
         /// </summary>
-        public Task<bool> Add(IEnumerable<T> values, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<bool> AddAsync(IEnumerable<T> values, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialized = values.Select(this.Connection.Converter.Serialize).ToArray();
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.HyperLogLogAddAsync(a.key, a.serialized, a.flags),
                 (key: this.Key, serialized, flags),
@@ -94,21 +94,21 @@ namespace CloudStructures.Structures
         /// <summary>
         /// PFCOUNT : http://redis.io/commands/pfcount
         /// </summary>
-        public Task<long> Length(CommandFlags flags = CommandFlags.None)
+        public Task<long> LengthAsync(CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.HyperLogLogLengthAsync(this.Key, flags);
 
 
         /// <summary>
         /// PFMERGE : https://redis.io/commands/pfmerge
         /// </summary>
-        public Task Merge(RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
+        public Task MergeAsync(RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.HyperLogLogMergeAsync(this.Key, first, second, flags);
 
 
         /// <summary>
         /// PFMERGE : https://redis.io/commands/pfmerge
         /// </summary>
-        public Task Merge(RedisKey[] sourceKeys, CommandFlags flags = CommandFlags.None)
+        public Task MergeAsync(RedisKey[] sourceKeys, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.HyperLogLogMergeAsync(this.Key, sourceKeys, flags);
         #endregion
     }

--- a/src/CloudStructures/Structures/RedisList.cs
+++ b/src/CloudStructures/Structures/RedisList.cs
@@ -72,7 +72,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// LINDEX : https://redis.io/commands/lindex
         /// </summary>
-        public async Task<RedisResult<T>> GetByIndex(long index, CommandFlags flags = CommandFlags.None)
+        public async Task<RedisResult<T>> GetByIndexAsync(long index, CommandFlags flags = CommandFlags.None)
         {
             var value = await this.Connection.Database.ListGetByIndexAsync(this.Key, index, flags).ConfigureAwait(false);
             return value.ToResult<T>(this.Connection.Converter);
@@ -82,12 +82,12 @@ namespace CloudStructures.Structures
         /// <summary>
         /// LINSERT : https://redis.io/commands/linsert
         /// </summary>
-        public Task<long> InsertAfter(T pivot, T value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<long> InsertAfterAsync(T pivot, T value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var p = this.Connection.Converter.Serialize(pivot);
             var v = this.Connection.Converter.Serialize(value);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.ListInsertAfterAsync(a.key, a.p, a.v, a.flags),
                 (key: this.Key, p, v, flags),
@@ -100,12 +100,12 @@ namespace CloudStructures.Structures
         /// <summary>
         /// LINSERT : https://redis.io/commands/linsert
         /// </summary>
-        public Task<long> InsertBefore(T pivot, T value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<long> InsertBeforeAsync(T pivot, T value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var p = this.Connection.Converter.Serialize(pivot);
             var v = this.Connection.Converter.Serialize(value);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.ListInsertBeforeAsync(a.key, a.p, a.v, a.flags),
                 (key: this.Key, p, v, flags),
@@ -118,7 +118,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// LPOP : https://redis.io/commands/lpop
         /// </summary>
-        public async Task<RedisResult<T>> LeftPop(CommandFlags flags = CommandFlags.None)
+        public async Task<RedisResult<T>> LeftPopAsync(CommandFlags flags = CommandFlags.None)
         {
             var value = await this.Connection.Database.ListLeftPopAsync(this.Key, flags).ConfigureAwait(false);
             return value.ToResult<T>(this.Connection.Converter);
@@ -128,11 +128,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// LPUSH : https://redis.io/commands/lpush
         /// </summary>
-        public Task<long> LeftPush(T value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        public Task<long> LeftPushAsync(T value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialized = this.Connection.Converter.Serialize(value);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.ListLeftPushAsync(a.key, a.serialized, a.when, a.flags),
                 (key: this.Key, serialized, when, flags),
@@ -145,11 +145,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// LPUSH : https://redis.io/commands/lpush
         /// </summary>
-        public Task<long> LeftPush(IEnumerable<T> values, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<long> LeftPushAsync(IEnumerable<T> values, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialized = values.Select(this.Connection.Converter.Serialize).ToArray();
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.ListLeftPushAsync(a.key, a.serialized, a.flags),
                 (key: this.Key, serialized, flags),
@@ -162,14 +162,14 @@ namespace CloudStructures.Structures
         /// <summary>
         /// LLEN : https://redis.io/commands/llen
         /// </summary>
-        public Task<long> Length(CommandFlags flags = CommandFlags.None)
+        public Task<long> LengthAsync(CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.ListLengthAsync(this.Key, flags);
 
 
         /// <summary>
         /// LRANGE : https://redis.io/commands/lrange
         /// </summary>
-        public async Task<T[]> Range(long start = 0, long stop = -1, CommandFlags flags = CommandFlags.None)
+        public async Task<T[]> RangeAsync(long start = 0, long stop = -1, CommandFlags flags = CommandFlags.None)
         {
             var values = await this.Connection.Database.ListRangeAsync(this.Key, start, stop, flags).ConfigureAwait(false);
             return values.Select(this.Connection.Converter, (x, c) => c.Deserialize<T>(x)).ToArray();
@@ -185,7 +185,7 @@ namespace CloudStructures.Structures
         /// <para>count &lt; 0 : 末尾から先頭に向かって検索しつつ削除</para>
         /// <para>count = 0 : 一致するものを全件削除</para>
         /// </param>
-        public Task<long> Remove(T value, long count = 0, CommandFlags flags = CommandFlags.None)
+        public Task<long> RemoveAsync(T value, long count = 0, CommandFlags flags = CommandFlags.None)
         {
             var serialized = this.Connection.Converter.Serialize(value);
             return this.Connection.Database.ListRemoveAsync(this.Key, serialized, count, flags);
@@ -195,7 +195,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// RPOP : https://redis.io/commands/rpop
         /// </summary>
-        public async Task<RedisResult<T>> RightPop(CommandFlags flags = CommandFlags.None)
+        public async Task<RedisResult<T>> RightPopAsync(CommandFlags flags = CommandFlags.None)
         {
             var value = await this.Connection.Database.ListRightPopAsync(this.Key, flags).ConfigureAwait(false);
             return value.ToResult<T>(this.Connection.Converter);
@@ -205,7 +205,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// RPOPLPUSH : https://redis.io/commands/rpoplpush
         /// </summary>
-        public async Task<RedisResult<T>> RightPopLeftPush(RedisList<T> destination, CommandFlags flags = CommandFlags.None)
+        public async Task<RedisResult<T>> RightPopLeftPushAsync(RedisList<T> destination, CommandFlags flags = CommandFlags.None)
         {
             var value = await this.Connection.Database.ListRightPopLeftPushAsync(this.Key, destination.Key, flags).ConfigureAwait(false);
             return value.ToResult<T>(this.Connection.Converter);
@@ -215,11 +215,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// RPUSH : https://redis.io/commands/rpush
         /// </summary>
-        public Task<long> RightPush(T value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        public Task<long> RightPushAsync(T value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialized = this.Connection.Converter.Serialize(value);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.ListRightPushAsync(a.key, a.serialized, a.when, a.flags),
                 (key: this.Key, serialized, when, flags),
@@ -232,11 +232,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// RPUSH : https://redis.io/commands/rpush
         /// </summary>
-        public Task<long> RightPush(IEnumerable<T> values, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<long> RightPushAsync(IEnumerable<T> values, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialized = values.Select(this.Connection.Converter.Serialize).ToArray();
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.ListRightPushAsync(a.key, a.serialized, a.flags),
                 (key: this.Key, serialized, flags),
@@ -249,11 +249,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// LSET : https://redis.io/commands/lset
         /// </summary>
-        public Task SetByIndex(long index, T value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task SetByIndexAsync(long index, T value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialized = this.Connection.Converter.Serialize(value);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.ListSetByIndexAsync(a.key, a.index, a.serialized, a.flags),
                 (key: this.Key, index, serialized, flags),
@@ -266,14 +266,14 @@ namespace CloudStructures.Structures
         /// <summary>
         /// LTRIM : https://redis.io/commands/ltrim
         /// </summary>
-        public Task Trim(long start, long stop, CommandFlags flags = CommandFlags.None)
+        public Task TrimAsync(long start, long stop, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.ListTrimAsync(this.Key, start, stop, flags);
 
 
         /// <summary>
         /// SORT : https://redis.io/commands/sort
         /// </summary>
-        public Task<long> SortAndStore(RedisList<T> destination, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
+        public Task<long> SortAndStoreAsync(RedisList<T> destination, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
         {
             //--- I don't know if serialization is necessary or not, so I will fix the default value.
             RedisValue by = default;
@@ -285,7 +285,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SORT : https://redis.io/commands/sort
         /// </summary>
-        public async Task<T[]> Sort(long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
+        public async Task<T[]> SortAsync(long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
         {
             //--- I don't know if serialization is necessary or not, so I will fix the default value.
             RedisValue by = default;
@@ -300,7 +300,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// First LPUSH, then LTRIM to the specified list length.
         /// </summary>
-        public async Task<long> FixedLengthLeftPush(T value, long length, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        public async Task<long> FixedLengthLeftPushAsync(T value, long length, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialized = this.Connection.Converter.Serialize(value);
@@ -324,7 +324,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// First LPUSH, then LTRIM to the specified list length.
         /// </summary>
-        public async Task<long> FixedLengthLeftPush(IEnumerable<T> values, long length, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public async Task<long> FixedLengthLeftPushAsync(IEnumerable<T> values, long length, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialized = values.Select(this.Connection.Converter.Serialize).ToArray();

--- a/src/CloudStructures/Structures/RedisLock.cs
+++ b/src/CloudStructures/Structures/RedisLock.cs
@@ -50,7 +50,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// Extends a lock, if the token value is correct.
         /// </summary>
-        public Task<bool> Extend(T value, TimeSpan expiry, CommandFlags flags = CommandFlags.None)
+        public Task<bool> ExtendAsync(T value, TimeSpan expiry, CommandFlags flags = CommandFlags.None)
         {
             var serialized = this.Connection.Converter.Serialize(value);
             return this.Connection.Database.LockExtendAsync(this.Key, serialized, expiry, flags);
@@ -60,7 +60,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// Queries the token held against a lock.
         /// </summary>
-        public async Task<RedisResult<T>> Query(CommandFlags flags = CommandFlags.None)
+        public async Task<RedisResult<T>> QueryAsync(CommandFlags flags = CommandFlags.None)
         {
             var value = await this.Connection.Database.LockQueryAsync(this.Key, flags).ConfigureAwait(false);
             return value.ToResult<T>(this.Connection.Converter);
@@ -70,7 +70,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// Releases a lock, if the token value is correct.
         /// </summary>
-        public Task<bool> Release(T value, CommandFlags flags = CommandFlags.None)
+        public Task<bool> ReleaseAsync(T value, CommandFlags flags = CommandFlags.None)
         {
             var serialized = this.Connection.Converter.Serialize(value);
             return this.Connection.Database.LockReleaseAsync(this.Key, serialized, flags);
@@ -80,7 +80,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// Takes a lock (specifying a token value) if it is not already taken.
         /// </summary>
-        public Task<bool> Take(T value, TimeSpan expiry, CommandFlags flags = CommandFlags.None)
+        public Task<bool> TakeAsync(T value, TimeSpan expiry, CommandFlags flags = CommandFlags.None)
         {
             var serialized = this.Connection.Converter.Serialize(value);
             return this.Connection.Database.LockTakeAsync(this.Key, serialized, expiry, flags);

--- a/src/CloudStructures/Structures/RedisLua.cs
+++ b/src/CloudStructures/Structures/RedisLua.cs
@@ -47,14 +47,14 @@ namespace CloudStructures.Structures
         /// <summary>
         /// EVALSHA : http://redis.io/commands/evalsha
         /// </summary>
-        public Task ScriptEvaluate(string script, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None)
+        public Task ScriptEvaluateAsync(string script, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.ScriptEvaluateAsync(script, keys, values, flags);
 
 
         /// <summary>
         /// EVALSHA : http://redis.io/commands/evalsha
         /// </summary>
-        public async Task<RedisResult<T>> ScriptEvaluate<T>(string script, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None)
+        public async Task<RedisResult<T>> ScriptEvaluateAsync<T>(string script, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None)
         {
             var result = await this.Connection.Database.ScriptEvaluateAsync(script, keys, values, flags).ConfigureAwait(false);
             if (result.IsNull)

--- a/src/CloudStructures/Structures/RedisSet.cs
+++ b/src/CloudStructures/Structures/RedisSet.cs
@@ -70,11 +70,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SADD : http://redis.io/commands/sadd
         /// </summary>
-        public Task<bool> Add(T value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<bool> AddAsync(T value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialised = this.Connection.Converter.Serialize(value);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.SetAddAsync(a.key, a.serialised, a.flags),
                 (key: this.Key, serialised, flags),
@@ -87,11 +87,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SADD : http://redis.io/commands/sadd
         /// </summary>
-        public Task<long> Add(IEnumerable<T> values, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<long> AddAsync(IEnumerable<T> values, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialised = values.Select(this.Connection.Converter.Serialize).ToArray();
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.SetAddAsync(a.key, a.serialised, a.flags),
                 (key: this.Key, serialised, flags),
@@ -110,7 +110,7 @@ namespace CloudStructures.Structures
         /// Combine self and other, then save it to the destination.
         /// It does not work unless you pass keys located the same server.
         /// </remarks>
-        public Task<long> CombineAndStore(SetOperation operation, RedisSet<T> destination, RedisSet<T> other, CommandFlags flags = CommandFlags.None)
+        public Task<long> CombineAndStoreAsync(SetOperation operation, RedisSet<T> destination, RedisSet<T> other, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.SetCombineAndStoreAsync(operation, destination.Key, this.Key, other.Key, flags);
 
 
@@ -123,7 +123,7 @@ namespace CloudStructures.Structures
         /// Combine self and other, then save it to the destination.
         /// It does not work unless you pass keys located the same server.
         /// </remarks>
-        public Task<long> CombineAndStore(SetOperation operation, RedisSet<T> destination, IReadOnlyCollection<RedisSet<T>> others, CommandFlags flags = CommandFlags.None)
+        public Task<long> CombineAndStoreAsync(SetOperation operation, RedisSet<T> destination, IReadOnlyCollection<RedisSet<T>> others, CommandFlags flags = CommandFlags.None)
         {
             if (others == null) throw new ArgumentNullException(nameof(others));
             if (others.Count == 0) throw new ArgumentException("others length is 0.");
@@ -139,7 +139,7 @@ namespace CloudStructures.Structures
         /// SUNION : https://redis.io/commands/sunion
         /// </summary>
         /// <remarks>It does not work unless you pass keys located the same server.</remarks>
-        public async Task<T[]> Combine(SetOperation operation, RedisSet<T> other, CommandFlags flags = CommandFlags.None)
+        public async Task<T[]> CombineAsync(SetOperation operation, RedisSet<T> other, CommandFlags flags = CommandFlags.None)
         {
             var values = await this.Connection.Database.SetCombineAsync(operation, this.Key, other.Key, flags).ConfigureAwait(false);
             return values.Select(this.Connection.Converter, (x, c) => c.Deserialize<T>(x)).ToArray();
@@ -152,7 +152,7 @@ namespace CloudStructures.Structures
         /// SUNION : https://redis.io/commands/sunion
         /// </summary>
         /// <remarks>It does not work unless you pass keys located the same server.</remarks>
-        public async Task<T[]> Combine(SetOperation operation, IReadOnlyCollection<RedisSet<T>> others, CommandFlags flags = CommandFlags.None)
+        public async Task<T[]> CombineAsync(SetOperation operation, IReadOnlyCollection<RedisSet<T>> others, CommandFlags flags = CommandFlags.None)
         {
             if (others == null) throw new ArgumentNullException(nameof(others));
             if (others.Count == 0) throw new ArgumentException("others length is 0.");
@@ -166,7 +166,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SISMEMBER : http://redis.io/commands/sismember
         /// </summary>
-        public Task<bool> Contains(T value, CommandFlags flags = CommandFlags.None)
+        public Task<bool> ContainsAsync(T value, CommandFlags flags = CommandFlags.None)
         {
             var serialized = this.Connection.Converter.Serialize(value);
             return this.Connection.Database.SetContainsAsync(this.Key, serialized, flags);
@@ -176,14 +176,14 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SCARD : http://redis.io/commands/scard
         /// </summary>
-        public Task<long> Length(CommandFlags flags = CommandFlags.None)
+        public Task<long> LengthAsync(CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.SetLengthAsync(this.Key, flags);
 
 
         /// <summary>
         /// SMEMBERS : https://redis.io/commands/smembers
         /// </summary>
-        public async Task<T[]> Members(CommandFlags flags = CommandFlags.None)
+        public async Task<T[]> MembersAsync(CommandFlags flags = CommandFlags.None)
         {
             var members = await this.Connection.Database.SetMembersAsync(this.Key, flags).ConfigureAwait(false);
             return members
@@ -195,7 +195,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SMOVE : https://redis.io/commands/smove
         /// </summary>
-        public Task<bool> Move(RedisSet<T> destination, T value, CommandFlags flags = CommandFlags.None)
+        public Task<bool> MoveAsync(RedisSet<T> destination, T value, CommandFlags flags = CommandFlags.None)
         {
             var serialized = this.Connection.Converter.Serialize(value);
             return this.Connection.Database.SetMoveAsync(this.Key, destination.Key, serialized, flags);
@@ -205,7 +205,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SPOP : http://redis.io/commands/spop
         /// </summary>
-        public async Task<RedisResult<T>> Pop(CommandFlags flags = CommandFlags.None)
+        public async Task<RedisResult<T>> PopAsync(CommandFlags flags = CommandFlags.None)
         {
             var value = await this.Connection.Database.SetPopAsync(this.Key, flags).ConfigureAwait(false);
             return value.ToResult<T>(this.Connection.Converter);
@@ -215,7 +215,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SRANDMEMBER : https://redis.io/commands/srandmember
         /// </summary>
-        public async Task<RedisResult<T>> RandomMember(CommandFlags flags = CommandFlags.None)
+        public async Task<RedisResult<T>> RandomMemberAsync(CommandFlags flags = CommandFlags.None)
         {
             var value = await this.Connection.Database.SetRandomMemberAsync(this.Key, flags).ConfigureAwait(false);
             return value.ToResult<T>(this.Connection.Converter);
@@ -225,7 +225,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SRANDMEMBER : https://redis.io/commands/srandmember
         /// </summary>
-        public async Task<T[]> RandomMember(long count, CommandFlags flags = CommandFlags.None)
+        public async Task<T[]> RandomMemberAsync(long count, CommandFlags flags = CommandFlags.None)
         {
             var values = await this.Connection.Database.SetRandomMembersAsync(this.Key, count, flags).ConfigureAwait(false);
             return values
@@ -237,7 +237,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SREM : http://redis.io/commands/srem
         /// </summary>
-        public Task<bool> Remove(T value, CommandFlags flags = CommandFlags.None)
+        public Task<bool> RemoveAsync(T value, CommandFlags flags = CommandFlags.None)
         {
             var serialized = this.Connection.Converter.Serialize(value);
             return this.Connection.Database.SetRemoveAsync(this.Key, serialized, flags);
@@ -247,7 +247,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SORT : https://redis.io/commands/sort
         /// </summary>
-        public Task<long> SortAndStore(RedisSet<T> destination, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
+        public Task<long> SortAndStoreAsync(RedisSet<T> destination, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
         {
             //--- I don't know if serialization is necessary or not, so I will fix the default value.
             RedisValue by = default;
@@ -259,7 +259,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SORT : https://redis.io/commands/sort
         /// </summary>
-        public async Task<T[]> Sort(long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
+        public async Task<T[]> SortAsync(long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
         {
             //--- I don't know if serialization is necessary or not, so I will fix the default value.
             RedisValue by = default;

--- a/src/CloudStructures/Structures/RedisSortedSet.cs
+++ b/src/CloudStructures/Structures/RedisSortedSet.cs
@@ -77,11 +77,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// ZADD : http://redis.io/commands/zadd
         /// </summary>
-        public Task<bool> Add(T value, double score, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        public Task<bool> AddAsync(T value, double score, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialized = this.Connection.Converter.Serialize(value);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.SortedSetAddAsync(a.key, a.serialized, a.score, a.when, a.flags),
                 (key: this.Key, serialized, score, when, flags),
@@ -94,14 +94,14 @@ namespace CloudStructures.Structures
         /// <summary>
         /// ZADD : http://redis.io/commands/zadd
         /// </summary>
-        public Task<long> Add(IEnumerable<RedisSortedSetEntry<T>> entries, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        public Task<long> AddAsync(IEnumerable<RedisSortedSetEntry<T>> entries, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var values
                 = entries
                 .Select(this.Connection.Converter, (x, c) => x.ToNonGenerics(c))
                 .ToArray();
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.SortedSetAddAsync(a.key, a.values, a.when, a.flags),
                 (key: this.Key, values, when, flags),
@@ -115,7 +115,7 @@ namespace CloudStructures.Structures
         /// ZUNIONSTORE : https://redis.io/commands/zunionstore
         /// ZINTERSTORE : https://redis.io/commands/zinterstore
         /// </summary>
-        public Task<long> CombineAndStore(SetOperation operation, RedisSortedSet<T> destination, RedisSortedSet<T> other, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        public Task<long> CombineAndStoreAsync(SetOperation operation, RedisSortedSet<T> destination, RedisSortedSet<T> other, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.SortedSetCombineAndStoreAsync(operation, destination.Key, this.Key, other.Key, aggregate, flags);
 
 
@@ -123,7 +123,7 @@ namespace CloudStructures.Structures
         /// ZUNIONSTORE : https://redis.io/commands/zunionstore
         /// ZINTERSTORE : https://redis.io/commands/zinterstore
         /// </summary>
-        public Task<long> CombineAndStore(SetOperation operation, RedisSortedSet<T> destination, IReadOnlyCollection<RedisSortedSet<T>> others, double[] weights = default, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        public Task<long> CombineAndStoreAsync(SetOperation operation, RedisSortedSet<T> destination, IReadOnlyCollection<RedisSortedSet<T>> others, double[] weights = default, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
         {
             if (others == null) throw new ArgumentNullException(nameof(others));
             if (others.Count == 0) throw new ArgumentNullException("others length is 0.");
@@ -136,11 +136,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// ZINCRBY : http://redis.io/commands/zincrby
         /// </summary>
-        public Task<double> Decrement(T member, double value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<double> DecrementAsync(T member, double value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialized = this.Connection.Converter.Serialize(member);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.SortedSetDecrementAsync(a.key, a.serialized, a.value, a.flags),
                 (key: this.Key, serialized, value, flags),
@@ -153,11 +153,11 @@ namespace CloudStructures.Structures
         /// <summary>
         /// ZINCRBY : http://redis.io/commands/zincrby
         /// </summary>
-        public Task<double> Increment(T member, double value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<double> IncrementAsync(T member, double value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialized = this.Connection.Converter.Serialize(member);
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.SortedSetIncrementAsync(a.key, a.serialized, a.value, a.flags),
                 (key: this.Key, serialized, value, flags),
@@ -171,7 +171,7 @@ namespace CloudStructures.Structures
         /// ZCARD  : http://redis.io/commands/zcard
         /// ZCOUNT : http://redis.io/commands/zcount
         /// </summary>
-        public Task<long> Length(double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        public Task<long> LengthAsync(double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.SortedSetLengthAsync(this.Key, min, max, exclude, flags);
 
 
@@ -179,7 +179,7 @@ namespace CloudStructures.Structures
         /// ZCARD  : http://redis.io/commands/zcard
         /// ZCOUNT : http://redis.io/commands/zcount
         /// </summary>
-        public Task<long> LengthByValue(T min, T max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        public Task<long> LengthByValueAsync(T min, T max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
         {
             var serializedMin = this.Connection.Converter.Serialize(min);
             var serializedMax = this.Connection.Converter.Serialize(max);
@@ -191,7 +191,7 @@ namespace CloudStructures.Structures
         /// ZRANGE    : https://redis.io/commands/zrange
         /// ZREVRANGE : https://redis.io/commands/zrevrange
         /// </summary>
-        public async Task<T[]> RangeByRank(long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        public async Task<T[]> RangeByRankAsync(long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
         {
             var values = await this.Connection.Database.SortedSetRangeByRankAsync(this.Key, start, stop, order, flags).ConfigureAwait(false);
             return values
@@ -204,7 +204,7 @@ namespace CloudStructures.Structures
         /// ZRANGE    : https://redis.io/commands/zrange
         /// ZREVRANGE : https://redis.io/commands/zrevrange
         /// </summary>
-        public async Task<RedisSortedSetEntry<T>[]> RangeByRankWithScores(long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        public async Task<RedisSortedSetEntry<T>[]> RangeByRankWithScoresAsync(long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
         {
             var values = await this.Connection.Database.SortedSetRangeByRankWithScoresAsync(this.Key, start, stop, order, flags).ConfigureAwait(false);
             return values
@@ -217,7 +217,7 @@ namespace CloudStructures.Structures
         /// ZRANGEBYSCORE    : https://redis.io/commands/zrangebyscore
         /// ZREVRANGEBYSCORE : https://redis.io/commands/zrevrangebyscore
         /// </summary>
-        public async Task<T[]> RangeByScore(double start = double.NegativeInfinity, double stop = double.PositiveInfinity, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        public async Task<T[]> RangeByScoreAsync(double start = double.NegativeInfinity, double stop = double.PositiveInfinity, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
         {
             var values = await this.Connection.Database.SortedSetRangeByScoreAsync(this.Key, start, stop, exclude, order, skip, take, flags).ConfigureAwait(false);
             return values
@@ -230,7 +230,7 @@ namespace CloudStructures.Structures
         /// ZRANGEBYSCORE    : https://redis.io/commands/zrangebyscore
         /// ZREVRANGEBYSCORE : https://redis.io/commands/zrevrangebyscore
         /// </summary>
-        public async Task<RedisSortedSetEntry<T>[]> RangeByScoreWithScores(double start = double.NegativeInfinity, double stop = double.PositiveInfinity, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        public async Task<RedisSortedSetEntry<T>[]> RangeByScoreWithScoresAsync(double start = double.NegativeInfinity, double stop = double.PositiveInfinity, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
         {
             var values = await this.Connection.Database.SortedSetRangeByScoreWithScoresAsync(this.Key, start, stop, exclude, order, skip, take, flags).ConfigureAwait(false);
             return values
@@ -243,7 +243,7 @@ namespace CloudStructures.Structures
         /// ZRANGEBYLEX    : https://redis.io/commands/zrangebylex
         /// ZREVRANGEBYLEX : https://redis.io/commands/zrevrangebylex
         /// </summary>
-        public async Task<T[]> RangeByValue(T min = default, T max = default, Exclude exclude = Exclude.None, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        public async Task<T[]> RangeByValueAsync(T min = default, T max = default, Exclude exclude = Exclude.None, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
         {
             var minValue = this.Connection.Converter.Serialize(min);
             var maxValue = this.Connection.Converter.Serialize(max);
@@ -257,7 +257,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// ZRANK : https://redis.io/commands/zrank
         /// </summary>
-        public Task<long?> Rank(T member, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        public Task<long?> RankAsync(T member, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
         {
             var serialized = this.Connection.Converter.Serialize(member);
             return this.Connection.Database.SortedSetRankAsync(this.Key, serialized, order, flags);
@@ -267,7 +267,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// ZREM : https://redis.io/commands/zrem
         /// </summary>
-        public Task<bool> Remove(T member, CommandFlags flags = CommandFlags.None)
+        public Task<bool> RemoveAsync(T member, CommandFlags flags = CommandFlags.None)
         {
             var serialized = this.Connection.Converter.Serialize(member);
             return this.Connection.Database.SortedSetRemoveAsync(this.Key, serialized, flags);
@@ -277,7 +277,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// ZREM : https://redis.io/commands/zrem
         /// </summary>
-        public Task<long> Remove(IEnumerable<T> members, CommandFlags flags = CommandFlags.None)
+        public Task<long> RemoveAsync(IEnumerable<T> members, CommandFlags flags = CommandFlags.None)
         {
             var serialized = members.Select(this.Connection.Converter.Serialize).ToArray();
             return this.Connection.Database.SortedSetRemoveAsync(this.Key, serialized, flags);
@@ -287,21 +287,21 @@ namespace CloudStructures.Structures
         /// <summary>
         /// ZREMRANGEBYRANK : http://redis.io/commands/zremrangebyrank
         /// </summary>
-        public Task<long> RemoveRangeByRank(long start, long stop, CommandFlags flags = CommandFlags.None)
+        public Task<long> RemoveRangeByRankAsync(long start, long stop, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.SortedSetRemoveRangeByRankAsync(this.Key, start, stop, flags);
 
 
         /// <summary>
         /// ZREMRANGEBYSCORE : https://redis.io/commands/zremrangebyscore
         /// </summary>
-        public Task<long> RemoveRangeByScore(double start, double stop, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        public Task<long> RemoveRangeByScoreAsync(double start, double stop, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.SortedSetRemoveRangeByScoreAsync(this.Key, start, stop, exclude, flags);
 
 
         /// <summary>
         /// ZREMRANGEBYLEX : https://redis.io/commands/zremrangebylex
         /// </summary>
-        public Task<long> RemoveRangeByValue(T min, T max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        public Task<long> RemoveRangeByValueAsync(T min, T max, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
         {
             var minValue = this.Connection.Converter.Serialize(min);
             var maxValue = this.Connection.Converter.Serialize(max);
@@ -312,7 +312,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// ZSCORE : https://redis.io/commands/zscore
         /// </summary>
-        public Task<double?> Score(T member, CommandFlags flags = CommandFlags.None)
+        public Task<double?> ScoreAsync(T member, CommandFlags flags = CommandFlags.None)
         {
             var serialized = this.Connection.Converter.Serialize(member);
             return this.Connection.Database.SortedSetScoreAsync(this.Key, serialized, flags);
@@ -322,7 +322,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SORT : https://redis.io/commands/sort
         /// </summary>
-        public Task<long> SortAndStore(RedisSortedSet<T> destination, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
+        public Task<long> SortAndStoreAsync(RedisSortedSet<T> destination, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
         {
             //--- I don't know if serialization is necessary or not, so I will fix the default value.
             RedisValue by = default;
@@ -334,7 +334,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SORT : https://redis.io/commands/sort
         /// </summary>
-        public async Task<T[]> Sort(long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
+        public async Task<T[]> SortAsync(long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
         {
             //--- I don't know if serialization is necessary or not, so I will fix the default value.
             RedisValue by = default;
@@ -349,7 +349,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// LUA Script including zincrby, zadd
         /// </summary>
-        public async Task<double> IncrementLimitByMin(T member, double value, double min, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public async Task<double> IncrementLimitByMinAsync(T member, double value, double min, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var script =
@@ -366,7 +366,7 @@ return tostring(x)";
             var serialized = this.Connection.Converter.Serialize(member);
             var values = new RedisValue[] { serialized, value, min };
             var result
-                = await this.ExecuteWithExpiry
+                = await this.ExecuteWithExpiryAsync
                 (
                     (db, a) => db.ScriptEvaluateAsync(a.script, a.keys, a.values, a.flags),
                     (script, keys, values, flags),
@@ -381,7 +381,7 @@ return tostring(x)";
         /// <summary>
         /// LUA Script including zincrby, zadd
         /// </summary>
-        public async Task<double> IncrementLimitByMax(T member, double value, double max, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public async Task<double> IncrementLimitByMaxAsync(T member, double value, double max, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var script =
@@ -398,7 +398,7 @@ return tostring(x)";
             var serialized = this.Connection.Converter.Serialize(member);
             var values = new RedisValue[] { serialized, value, max };
             var result
-                = await this.ExecuteWithExpiry
+                = await this.ExecuteWithExpiryAsync
                 (
                     (db, a) => db.ScriptEvaluateAsync(a.script, a.keys, a.values, a.flags),
                     (script, keys, values, flags),

--- a/src/CloudStructures/Structures/RedisString.cs
+++ b/src/CloudStructures/Structures/RedisString.cs
@@ -65,10 +65,10 @@ namespace CloudStructures.Structures
         /// <summary>
         /// DECRBY : http://redis.io/commands/decrby
         /// </summary>
-        public Task<long> Decrement(long value = 1, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<long> DecrementAsync(long value = 1, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.StringDecrementAsync(a.key, a.value, a.flags),
                 (key: this.Key, value, flags),
@@ -81,10 +81,10 @@ namespace CloudStructures.Structures
         /// <summary>
         /// INCRBYFLOAT : http://redis.io/commands/incrbyfloat
         /// </summary>
-        public Task<double> Decrement(double value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<double> DecrementAsync(double value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.StringDecrementAsync(a.key, a.value, a.flags),
                 (key: this.Key, value, flags),
@@ -97,7 +97,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// GET : http://redis.io/commands/get
         /// </summary>
-        public async Task<RedisResult<T>> Get(CommandFlags flags = CommandFlags.None)
+        public async Task<RedisResult<T>> GetAsync(CommandFlags flags = CommandFlags.None)
         {
             var value = await this.Connection.Database.StringGetAsync(Key, flags).ConfigureAwait(false);
             return value.ToResult<T>(this.Connection.Converter);
@@ -107,12 +107,12 @@ namespace CloudStructures.Structures
         /// <summary>
         /// GETSET : http://redis.io/commands/getset
         /// </summary>
-        public async Task<RedisResult<T>> GetSet(T value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public async Task<RedisResult<T>> GetSetAsync(T value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialized = this.Connection.Converter.Serialize(value);
             var result
-                = await this.ExecuteWithExpiry
+                = await this.ExecuteWithExpiryAsync
                 (
                     (db, a) => db.StringGetSetAsync(a.key, a.serialized, a.flags),
                     (key: this.Key, serialized, flags),
@@ -127,7 +127,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// GET : http://redis.io/commands/get
         /// </summary>
-        public async Task<RedisResultWithExpiry<T>> GetWithExpiry(CommandFlags flags = CommandFlags.None)
+        public async Task<RedisResultWithExpiry<T>> GetWithExpiryAsync(CommandFlags flags = CommandFlags.None)
         {
             var value = await this.Connection.Database.StringGetWithExpiryAsync(this.Key, flags).ConfigureAwait(false);
             return value.ToResult<T>(this.Connection.Converter);
@@ -137,10 +137,10 @@ namespace CloudStructures.Structures
         /// <summary>
         /// INCRBY : http://redis.io/commands/incrby
         /// </summary>
-        public Task<long> Increment(long value = 1, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<long> IncrementAsync(long value = 1, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.StringIncrementAsync(a.key, a.value, a.flags),
                 (key: this.Key, value, flags),
@@ -153,10 +153,10 @@ namespace CloudStructures.Structures
         /// <summary>
         /// INCRBYFLOAT : http://redis.io/commands/incrbyfloat
         /// </summary>
-        public Task<double> Increment(double value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<double> IncrementAsync(double value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
-            return this.ExecuteWithExpiry
+            return this.ExecuteWithExpiryAsync
             (
                 (db, a) => db.StringIncrementAsync(a.key, a.value, a.flags),
                 (key: this.Key, value, flags),
@@ -169,14 +169,14 @@ namespace CloudStructures.Structures
         /// <summary>
         /// STRLEN : https://redis.io/commands/strlen
         /// </summary>
-        public Task<long> Length(CommandFlags flags = CommandFlags.None)
+        public Task<long> LengthAsync(CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.StringLengthAsync(this.Key, flags);
 
 
         /// <summary>
         /// SET : http://redis.io/commands/set
         /// </summary>
-        public Task<bool> Set(T value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
+        public Task<bool> SetAsync(T value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var serialized = this.Connection.Converter.Serialize(value);
@@ -190,10 +190,10 @@ namespace CloudStructures.Structures
         /// GET : http://redis.io/commands/get
         /// SET : http://redis.io/commands/set
         /// </summary>
-        public async Task<T> GetOrSet(Func<T> valueFactory, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public async Task<T> GetOrSetAsync(Func<T> valueFactory, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
-            var value = await this.Get(flags).ConfigureAwait(false);
+            var value = await this.GetAsync(flags).ConfigureAwait(false);
             if (value.HasValue)
             {
                 return value.Value;
@@ -201,7 +201,7 @@ namespace CloudStructures.Structures
             else
             {
                 var newValue = valueFactory();
-                await this.Set(newValue, expiry, When.Always, flags).ConfigureAwait(false);
+                await this.SetAsync(newValue, expiry, When.Always, flags).ConfigureAwait(false);
                 return newValue;
             }
         }
@@ -211,10 +211,10 @@ namespace CloudStructures.Structures
         /// GET : http://redis.io/commands/get
         /// SET : http://redis.io/commands/set
         /// </summary>
-        public async Task<T> GetOrSet(Func<Task<T>> valueFactory, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public async Task<T> GetOrSetAsync(Func<Task<T>> valueFactory, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
-            var value = await this.Get(flags).ConfigureAwait(false);
+            var value = await this.GetAsync(flags).ConfigureAwait(false);
             if (value.HasValue)
             {
                 return value.Value;
@@ -222,7 +222,7 @@ namespace CloudStructures.Structures
             else
             {
                 var newValue = await valueFactory().ConfigureAwait(false);
-                await this.Set(newValue, expiry, When.Always, flags).ConfigureAwait(false);
+                await this.SetAsync(newValue, expiry, When.Always, flags).ConfigureAwait(false);
                 return newValue;
             }
         }
@@ -231,7 +231,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// LUA Script including incrby, set
         /// </summary>
-        public async Task<long> IncrementLimitByMax(long value, long max, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public async Task<long> IncrementLimitByMaxAsync(long value, long max, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var script =
@@ -246,7 +246,7 @@ return x";
             var keys = new[] { this.Key };
             var values = new RedisValue[] { value, max };
             var result
-                = await this.ExecuteWithExpiry
+                = await this.ExecuteWithExpiryAsync
                 (
                     (db, a) => db.ScriptEvaluateAsync(a.script, a.keys, a.values, a.flags),
                     (script, keys, values, flags),
@@ -261,7 +261,7 @@ return x";
         /// <summary>
         /// LUA Script including incrbyfloat, set
         /// </summary>
-        public async Task<double> IncrementLimitByMax(double value, double max, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public async Task<double> IncrementLimitByMaxAsync(double value, double max, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var script =
@@ -276,7 +276,7 @@ return tostring(x)";
             var keys = new[] { this.Key };
             var values = new RedisValue[] { value, max };
             var result
-                = await this.ExecuteWithExpiry
+                = await this.ExecuteWithExpiryAsync
                 (
                     (db, a) => db.ScriptEvaluateAsync(a.script, a.keys, a.values, a.flags),
                     (script, keys, values, flags),
@@ -291,7 +291,7 @@ return tostring(x)";
         /// <summary>
         /// LUA Script including incrby, set
         /// </summary>
-        public async Task<long> IncrementLimitByMin(long value, long min, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public async Task<long> IncrementLimitByMinAsync(long value, long min, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var script =
@@ -306,7 +306,7 @@ return x";
             var keys = new[] { this.Key };
             var values = new RedisValue[] { value, min };
             var result
-                = await this.ExecuteWithExpiry
+                = await this.ExecuteWithExpiryAsync
                 (
                     (db, a) => db.ScriptEvaluateAsync(a.script, a.keys, a.values, a.flags),
                     (script, keys, values, flags),
@@ -321,7 +321,7 @@ return x";
         /// <summary>
         /// LUA Script including incrbyfloat, set
         /// </summary>
-        public async Task<double> IncrementLimitByMin(double value, double min, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public async Task<double> IncrementLimitByMinAsync(double value, double min, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry = expiry ?? this.DefaultExpiry;
             var script =
@@ -336,7 +336,7 @@ return tostring(x)";
             var keys = new[] { this.Key };
             var values = new RedisValue[] { value, min };
             var result
-                = await this.ExecuteWithExpiry
+                = await this.ExecuteWithExpiryAsync
                 (
                     (db, a) => db.ScriptEvaluateAsync(a.script, a.keys, a.values, a.flags),
                     (script, keys, values, flags),


### PR DESCRIPTION
# Motivation
Historically, CloudStructures has been chosen NOT to give `Async` suffix to async method. Now, we think this choice was wrong. Therefore, we would love to change naming policy of async method.

- [CloudStructures 1.0 - StackExchange.Redis対応、RedisInfoタブ(Glimpse)](http://neue.cc/2015/02/06_504.html)


# Changes
This pull-request contains breaking changes.

- Adds `Async` suffix to async method
- Micro bug fix