### PR TITLE
Add GetAndDeleteAsync methods

### DIFF
--- a/src/CloudStructures.Converters.MessagePack/CloudStructures.Converters.MessagePack.csproj
+++ b/src/CloudStructures.Converters.MessagePack/CloudStructures.Converters.MessagePack.csproj
@@ -8,7 +8,7 @@
         <!-- NuGet -->
         <IsPackable>true</IsPackable>
         <PackageId>CloudStructures.Converters.MessagePack</PackageId>
-        <Version>2.2.0.0</Version>
+        <Version>2.3.0.0</Version>
         <Description>Provides MessagePackConverter for CloudStructures.</Description>
         <PackageProjectUrl>https://github.com/neuecc/CloudStructures</PackageProjectUrl>
         <PackageIconUrl></PackageIconUrl>

--- a/src/CloudStructures/CloudStructures.csproj
+++ b/src/CloudStructures/CloudStructures.csproj
@@ -7,7 +7,7 @@
         <!-- NuGet -->
         <IsPackable>true</IsPackable>
         <PackageId>CloudStructures</PackageId>
-        <Version>2.2.0.0</Version>
+        <Version>2.3.0.0</Version>
         <Description>Redis Client based on StackExchange.Redis.</Description>
         <PackageProjectUrl>https://github.com/neuecc/CloudStructures</PackageProjectUrl>
         <PackageIconUrl></PackageIconUrl>

--- a/src/CloudStructures/Structures/RedisString.cs
+++ b/src/CloudStructures/Structures/RedisString.cs
@@ -229,6 +229,20 @@ namespace CloudStructures.Structures
 
 
         /// <summary>
+        /// GET : http://redis.io/commands/get
+        /// DEL : http://redis.io/commands/del
+        /// </summary>
+        /// <param name="flags"></param>
+        /// <returns></returns>
+        public async Task<RedisResult<T>> GetAndDeleteAsync(CommandFlags flags = CommandFlags.None)
+        {
+            var result = await this.GetAsync(flags).ConfigureAwait(false);
+            await this.DeleteAsync(flags).ConfigureAwait(false);
+            return result;
+        }
+
+
+        /// <summary>
         /// LUA Script including incrby, set
         /// </summary>
         public async Task<long> IncrementLimitByMaxAsync(long value, long max, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)


### PR DESCRIPTION
# Motivation

When using `RedisString` / `RedisDictionary` like web session, we often want to delete the key immediately after getting the value.

So this Pull-Request provides that these methods are added to treat such cases.