### PR TITLE
Remove public in keyword

### DIFF
--- a/src/CloudStructures/Structures/RedisBit.cs
+++ b/src/CloudStructures/Structures/RedisBit.cs
@@ -41,7 +41,7 @@ namespace CloudStructures.Structures
         /// <param name="connection"></param>
         /// <param name="key"></param>
         /// <param name="defaultExpiry"></param>
-        public RedisBit(RedisConnection connection, in RedisKey key, TimeSpan? defaultExpiry)
+        public RedisBit(RedisConnection connection, RedisKey key, TimeSpan? defaultExpiry)
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this.Key = key;
@@ -68,7 +68,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// BITOP : https://redis.io/commands/bitop
         /// </summary>
-        public Task<long> OperationAsync(Bitwise operation, in RedisBit first, RedisBit? second = null, CommandFlags flags = CommandFlags.None)
+        public Task<long> OperationAsync(Bitwise operation, RedisBit first, RedisBit? second = null, CommandFlags flags = CommandFlags.None)
         {
             var firstKey = first.Key;
             var secondKey = second?.Key ?? default; 

--- a/src/CloudStructures/Structures/RedisDictionary.cs
+++ b/src/CloudStructures/Structures/RedisDictionary.cs
@@ -43,7 +43,7 @@ namespace CloudStructures.Structures
         /// <param name="connection"></param>
         /// <param name="key"></param>
         /// <param name="defaultExpiry"></param>
-        public RedisDictionary(RedisConnection connection, in RedisKey key, TimeSpan? defaultExpiry)
+        public RedisDictionary(RedisConnection connection, RedisKey key, TimeSpan? defaultExpiry)
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this.Key = key;

--- a/src/CloudStructures/Structures/RedisGeo.cs
+++ b/src/CloudStructures/Structures/RedisGeo.cs
@@ -43,7 +43,7 @@ namespace CloudStructures.Structures
         /// <param name="connection"></param>
         /// <param name="key"></param>
         /// <param name="defaultExpiry"></param>
-        public RedisGeo(RedisConnection connection, in RedisKey key, TimeSpan? defaultExpiry)
+        public RedisGeo(RedisConnection connection, RedisKey key, TimeSpan? defaultExpiry)
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this.Key = key;
@@ -64,7 +64,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// GEOADD : https://redis.io/commands/geoadd
         /// </summary>
-        public Task<bool> AddAsync(in RedisGeoEntry<T> value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
+        public Task<bool> AddAsync(RedisGeoEntry<T> value, TimeSpan? expiry = null, CommandFlags flags = CommandFlags.None)
         {
             expiry ??= this.DefaultExpiry;
             var entry = value.ToNonGenerics(this.Connection.Converter);

--- a/src/CloudStructures/Structures/RedisHashSet.cs
+++ b/src/CloudStructures/Structures/RedisHashSet.cs
@@ -43,7 +43,7 @@ namespace CloudStructures.Structures
         /// <param name="connection"></param>
         /// <param name="key"></param>
         /// <param name="defaultExpiry"></param>
-        public RedisHashSet(RedisConnection connection, in RedisKey key, TimeSpan? defaultExpiry)
+        public RedisHashSet(RedisConnection connection, RedisKey key, TimeSpan? defaultExpiry)
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this.Key = key;

--- a/src/CloudStructures/Structures/RedisHyperLogLog.cs
+++ b/src/CloudStructures/Structures/RedisHyperLogLog.cs
@@ -42,7 +42,7 @@ namespace CloudStructures.Structures
         /// <param name="connection"></param>
         /// <param name="key"></param>
         /// <param name="defaultExpiry"></param>
-        public RedisHyperLogLog(RedisConnection connection, in RedisKey key, TimeSpan? defaultExpiry)
+        public RedisHyperLogLog(RedisConnection connection, RedisKey key, TimeSpan? defaultExpiry)
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this.Key = key;
@@ -101,7 +101,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// PFMERGE : https://redis.io/commands/pfmerge
         /// </summary>
-        public Task MergeAsync(in RedisKey first, in RedisKey second, CommandFlags flags = CommandFlags.None)
+        public Task MergeAsync(RedisKey first, RedisKey second, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.HyperLogLogMergeAsync(this.Key, first, second, flags);
 
 

--- a/src/CloudStructures/Structures/RedisList.cs
+++ b/src/CloudStructures/Structures/RedisList.cs
@@ -42,7 +42,7 @@ namespace CloudStructures.Structures
         /// <param name="connection"></param>
         /// <param name="key"></param>
         /// <param name="defaultExpiry"></param>
-        public RedisList(RedisConnection connection, in RedisKey key, TimeSpan? defaultExpiry)
+        public RedisList(RedisConnection connection, RedisKey key, TimeSpan? defaultExpiry)
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this.Key = key;

--- a/src/CloudStructures/Structures/RedisLock.cs
+++ b/src/CloudStructures/Structures/RedisLock.cs
@@ -32,7 +32,7 @@ namespace CloudStructures.Structures
         /// </summary>
         /// <param name="connection"></param>
         /// <param name="key"></param>
-        public RedisLock(RedisConnection connection, in RedisKey key)
+        public RedisLock(RedisConnection connection, RedisKey key)
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this.Key = key;

--- a/src/CloudStructures/Structures/RedisLua.cs
+++ b/src/CloudStructures/Structures/RedisLua.cs
@@ -32,7 +32,7 @@ namespace CloudStructures.Structures
         /// </summary>
         /// <param name="connection"></param>
         /// <param name="key"></param>
-        public RedisLua(RedisConnection connection, in RedisKey key)
+        public RedisLua(RedisConnection connection, RedisKey key)
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this.Key = key;

--- a/src/CloudStructures/Structures/RedisSet.cs
+++ b/src/CloudStructures/Structures/RedisSet.cs
@@ -42,7 +42,7 @@ namespace CloudStructures.Structures
         /// <param name="connection"></param>
         /// <param name="key"></param>
         /// <param name="defaultExpiry"></param>
-        public RedisSet(RedisConnection connection, in RedisKey key, TimeSpan? defaultExpiry)
+        public RedisSet(RedisConnection connection, RedisKey key, TimeSpan? defaultExpiry)
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this.Key = key;
@@ -110,7 +110,7 @@ namespace CloudStructures.Structures
         /// Combine self and other, then save it to the destination.
         /// It does not work unless you pass keys located the same server.
         /// </remarks>
-        public Task<long> CombineAndStoreAsync(SetOperation operation, in RedisSet<T> destination, in RedisSet<T> other, CommandFlags flags = CommandFlags.None)
+        public Task<long> CombineAndStoreAsync(SetOperation operation, RedisSet<T> destination, RedisSet<T> other, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.SetCombineAndStoreAsync(operation, destination.Key, this.Key, other.Key, flags);
 
 
@@ -123,7 +123,7 @@ namespace CloudStructures.Structures
         /// Combine self and other, then save it to the destination.
         /// It does not work unless you pass keys located the same server.
         /// </remarks>
-        public Task<long> CombineAndStoreAsync(SetOperation operation, in RedisSet<T> destination, IReadOnlyCollection<RedisSet<T>> others, CommandFlags flags = CommandFlags.None)
+        public Task<long> CombineAndStoreAsync(SetOperation operation, RedisSet<T> destination, IReadOnlyCollection<RedisSet<T>> others, CommandFlags flags = CommandFlags.None)
         {
             if (others == null) throw new ArgumentNullException(nameof(others));
             if (others.Count == 0) throw new ArgumentException("others length is 0.");
@@ -195,7 +195,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SMOVE : https://redis.io/commands/smove
         /// </summary>
-        public Task<bool> MoveAsync(in RedisSet<T> destination, T value, CommandFlags flags = CommandFlags.None)
+        public Task<bool> MoveAsync(RedisSet<T> destination, T value, CommandFlags flags = CommandFlags.None)
         {
             var serialized = this.Connection.Converter.Serialize(value);
             return this.Connection.Database.SetMoveAsync(this.Key, destination.Key, serialized, flags);
@@ -247,7 +247,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SORT : https://redis.io/commands/sort
         /// </summary>
-        public Task<long> SortAndStoreAsync(in RedisSet<T> destination, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
+        public Task<long> SortAndStoreAsync(RedisSet<T> destination, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
         {
             //--- I don't know if serialization is necessary or not, so I will fix the default value.
             RedisValue by = default;

--- a/src/CloudStructures/Structures/RedisSortedSet.cs
+++ b/src/CloudStructures/Structures/RedisSortedSet.cs
@@ -43,7 +43,7 @@ namespace CloudStructures.Structures
         /// <param name="connection"></param>
         /// <param name="key"></param>
         /// <param name="defaultExpiry"></param>
-        public RedisSortedSet(RedisConnection connection, in RedisKey key, TimeSpan? defaultExpiry)
+        public RedisSortedSet(RedisConnection connection, RedisKey key, TimeSpan? defaultExpiry)
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this.Key = key;
@@ -115,7 +115,7 @@ namespace CloudStructures.Structures
         /// ZUNIONSTORE : https://redis.io/commands/zunionstore
         /// ZINTERSTORE : https://redis.io/commands/zinterstore
         /// </summary>
-        public Task<long> CombineAndStoreAsync(SetOperation operation, in RedisSortedSet<T> destination, in RedisSortedSet<T> other, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        public Task<long> CombineAndStoreAsync(SetOperation operation, RedisSortedSet<T> destination, RedisSortedSet<T> other, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
             => this.Connection.Database.SortedSetCombineAndStoreAsync(operation, destination.Key, this.Key, other.Key, aggregate, flags);
 
 
@@ -123,7 +123,7 @@ namespace CloudStructures.Structures
         /// ZUNIONSTORE : https://redis.io/commands/zunionstore
         /// ZINTERSTORE : https://redis.io/commands/zinterstore
         /// </summary>
-        public Task<long> CombineAndStoreAsync(SetOperation operation, in RedisSortedSet<T> destination, IReadOnlyCollection<RedisSortedSet<T>> others, double[] weights = default, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
+        public Task<long> CombineAndStoreAsync(SetOperation operation, RedisSortedSet<T> destination, IReadOnlyCollection<RedisSortedSet<T>> others, double[] weights = default, Aggregate aggregate = Aggregate.Sum, CommandFlags flags = CommandFlags.None)
         {
             if (others == null) throw new ArgumentNullException(nameof(others));
             if (others.Count == 0) throw new ArgumentNullException("others length is 0.");
@@ -322,7 +322,7 @@ namespace CloudStructures.Structures
         /// <summary>
         /// SORT : https://redis.io/commands/sort
         /// </summary>
-        public Task<long> SortAndStoreAsync(in RedisSortedSet<T> destination, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
+        public Task<long> SortAndStoreAsync(RedisSortedSet<T> destination, long skip = 0, long take = -1, Order order = Order.Ascending, SortType sortType = SortType.Numeric, /*RedisValue by = default, RedisValue[] get = null,*/ CommandFlags flags = CommandFlags.None)
         {
             //--- I don't know if serialization is necessary or not, so I will fix the default value.
             RedisValue by = default;

--- a/src/CloudStructures/Structures/RedisString.cs
+++ b/src/CloudStructures/Structures/RedisString.cs
@@ -40,7 +40,7 @@ namespace CloudStructures.Structures
         /// <param name="connection"></param>
         /// <param name="key"></param>
         /// <param name="defaultExpiry"></param>
-        public RedisString(RedisConnection connection, in RedisKey key, TimeSpan? defaultExpiry)
+        public RedisString(RedisConnection connection, RedisKey key, TimeSpan? defaultExpiry)
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this.Key = key;


### PR DESCRIPTION
It's unknown whether the compiler or the IDE reason, however it seems to be breaking change. So the public `in` keyword is abolished.