### PR TITLE
Add Memory<byte> value converter

### DIFF
--- a/src/CloudStructures/Converters/PrimitiveConverter.cs
+++ b/src/CloudStructures/Converters/PrimitiveConverter.cs
@@ -1,4 +1,5 @@
-﻿using StackExchange.Redis;
+﻿using System;
+using StackExchange.Redis;
 
 
 
@@ -286,5 +287,27 @@ namespace CloudStructures.Converters
     {
         public RedisValue Serialize(byte[] value) => value;
         public byte[] Deserialize(RedisValue value) => value;
+    }
+
+
+
+    /// <summary>
+    /// Provides <see cref="Memory{byte}"/> conversion function.
+    /// </summary>
+    internal sealed class MemoryByteConverter : IRedisValueConverter<Memory<byte>>
+    {
+        public RedisValue Serialize(Memory<byte> value) => value;
+        public Memory<byte> Deserialize(RedisValue value) => (byte[])value;
+    }
+
+
+
+    /// <summary>
+    /// Provides <see cref="ReadOnlyMemory{byte}"/> conversion function.
+    /// </summary>
+    internal sealed class ReadOnlyMemoryByteConverter : IRedisValueConverter<ReadOnlyMemory<byte>>
+    {
+        public RedisValue Serialize(ReadOnlyMemory<byte> value) => value;
+        public ReadOnlyMemory<byte> Deserialize(RedisValue value) => value;
     }
 }

--- a/src/CloudStructures/Converters/ValueConverter.cs
+++ b/src/CloudStructures/Converters/ValueConverter.cs
@@ -70,7 +70,7 @@ namespace CloudStructures.Converters
             /// <summary>
             /// Hold type and converter mapping table.
             /// </summary>
-            public static IDictionary<Type, object> Map { get; } = new Dictionary<Type, object>
+            public static IReadOnlyDictionary<Type, object> Map { get; } = new Dictionary<Type, object>
             {
                 [typeof(bool)] = new BooleanConverter(),
                 [typeof(bool?)] = new NullableBooleanConverter(),

--- a/src/CloudStructures/Converters/ValueConverter.cs
+++ b/src/CloudStructures/Converters/ValueConverter.cs
@@ -98,6 +98,8 @@ namespace CloudStructures.Converters
                 [typeof(double?)] = new NullableDoubleConverter(),
                 [typeof(string)] = new StringConverter(),
                 [typeof(byte[])] = new ByteArrayConverter(),
+                [typeof(Memory<byte>)] = new MemoryByteConverter(),
+                [typeof(ReadOnlyMemory<byte>)] = new ReadOnlyMemoryByteConverter(),
             };
         }
 


### PR DESCRIPTION
`RedisValue` allows implicit cast from/to `Memory<byte>` / `ReadOnlyMemory<byte>`. Therefore, we can avoid fallback to custom converter by preparing primitive converter.