### PR TITLE
Supports GETDEL + LPOP (w/count) + RPOP (w/count)

### DIFF
--- a/src/CloudStructures/Structures/RedisList.cs
+++ b/src/CloudStructures/Structures/RedisList.cs
@@ -126,6 +126,16 @@ public readonly struct RedisList<T> : IRedisStructureWithExpiry
 
 
     /// <summary>
+    /// LPOP : <a href="https://redis.io/commands/lpop"></a>
+    /// </summary>
+    public async Task<T[]?> LeftPopAsync(long count, CommandFlags flags = CommandFlags.None)
+    {
+        var values = await this.Connection.Database.ListLeftPopAsync(this.Key, count, flags).ConfigureAwait(false);
+        return values?.Select(this.Connection.Converter, static (x, c) => c.Deserialize<T>(x)).ToArray();
+    }
+
+
+    /// <summary>
     /// LPUSH : <a href="https://redis.io/commands/lpush"></a>
     /// </summary>
     public Task<long> LeftPushAsync(T value, TimeSpan? expiry = null, When when = When.Always, CommandFlags flags = CommandFlags.None)
@@ -202,6 +212,16 @@ public readonly struct RedisList<T> : IRedisStructureWithExpiry
     {
         var value = await this.Connection.Database.ListRightPopAsync(this.Key, flags).ConfigureAwait(false);
         return value.ToResult<T>(this.Connection.Converter);
+    }
+
+
+    /// <summary>
+    /// RPOP : <a href="https://redis.io/commands/rpop"></a>
+    /// </summary>
+    public async Task<T[]?> RightPopAsync(long count, CommandFlags flags = CommandFlags.None)
+    {
+        var values = await this.Connection.Database.ListRightPopAsync(this.Key, count, flags).ConfigureAwait(false);
+        return values?.Select(this.Connection.Converter, static (x, c) => c.Deserialize<T>(x)).ToArray();
     }
 
 

--- a/src/CloudStructures/Structures/RedisString.cs
+++ b/src/CloudStructures/Structures/RedisString.cs
@@ -53,6 +53,7 @@ public readonly struct RedisString<T> : IRedisStructureWithExpiry
     //- [] StringAppendAsync
     //- [x] StringDecrementAsync
     //- [x] StringGetAsync
+    //- [x] StringGetDeleteAsync
     //- [] StringGetRangeAsync
     //- [x] StringGetSetAsync
     //- [x] StringGetWithExpiryAsync
@@ -100,6 +101,16 @@ public readonly struct RedisString<T> : IRedisStructureWithExpiry
     public async Task<RedisResult<T>> GetAsync(CommandFlags flags = CommandFlags.None)
     {
         var value = await this.Connection.Database.StringGetAsync(Key, flags).ConfigureAwait(false);
+        return value.ToResult<T>(this.Connection.Converter);
+    }
+
+
+    /// <summary>
+    /// GETDEL : <a href="https://redis.io/commands/getdel"></a>
+    /// </summary>
+    public async Task<RedisResult<T>> GetDeleteAsync(CommandFlags flags = CommandFlags.None)
+    {
+        var value = await this.Connection.Database.StringGetDeleteAsync(Key, flags).ConfigureAwait(false);
         return value.ToResult<T>(this.Connection.Converter);
     }
 

--- a/src/CloudStructures/Structures/RedisString.cs
+++ b/src/CloudStructures/Structures/RedisString.cs
@@ -100,7 +100,7 @@ public readonly struct RedisString<T> : IRedisStructureWithExpiry
     /// </summary>
     public async Task<RedisResult<T>> GetAsync(CommandFlags flags = CommandFlags.None)
     {
-        var value = await this.Connection.Database.StringGetAsync(Key, flags).ConfigureAwait(false);
+        var value = await this.Connection.Database.StringGetAsync(this.Key, flags).ConfigureAwait(false);
         return value.ToResult<T>(this.Connection.Converter);
     }
 
@@ -110,7 +110,7 @@ public readonly struct RedisString<T> : IRedisStructureWithExpiry
     /// </summary>
     public async Task<RedisResult<T>> GetDeleteAsync(CommandFlags flags = CommandFlags.None)
     {
-        var value = await this.Connection.Database.StringGetDeleteAsync(Key, flags).ConfigureAwait(false);
+        var value = await this.Connection.Database.StringGetDeleteAsync(this.Key, flags).ConfigureAwait(false);
         return value.ToResult<T>(this.Connection.Converter);
     }
 


### PR DESCRIPTION
The new methods that StackExchange.Redis now supports are wrapped.

- https://redis.io/commands/getdel
- https://redis.io/commands/lpop
    - support `count` overload
- https://redis.io/commands/rpop
    - support `count` overload