### PR TITLE
Add server maintenance event

### DIFF
--- a/src/CloudStructures/IConnectionEventHandler.cs
+++ b/src/CloudStructures/IConnectionEventHandler.cs
@@ -1,4 +1,5 @@
 ﻿using StackExchange.Redis;
+using StackExchange.Redis.Maintenance;
 
 namespace CloudStructures;
 
@@ -72,4 +73,12 @@ public interface IConnectionEventHandler
     /// <param name="sender"></param>
     /// <param name="e"></param>
     void OnInternalError(RedisConnection sender, InternalErrorEventArgs e);
+
+
+    /// <summary>
+    /// Raised when server indicates a maintenance event is going to happen.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    void OnServerMaintenanceEvent(RedisConnection sender, ServerMaintenanceEvent e);
 }

--- a/src/CloudStructures/RedisConnection.cs
+++ b/src/CloudStructures/RedisConnection.cs
@@ -112,6 +112,7 @@ public sealed class RedisConnection
                     this._connection.ErrorMessage += (_, e) => this.Handler?.OnErrorMessage(this, e);
                     this._connection.HashSlotMoved += (_, e) => this.Handler?.OnHashSlotMoved(this, e);
                     this._connection.InternalError += (_, e) => this.Handler?.OnInternalError(this, e);
+                    this._connection.ServerMaintenanceEvent += (_, e) => this.Handler?.OnServerMaintenanceEvent(this, e);
                 }
                 catch
                 {


### PR DESCRIPTION
StackExchange.Redis provides `ServerMaintenanceEvent` to handle notifications about upcoming maintenance from supported Redis providers. Detail document is following.

- [Introducing ServerMaintenanceEvents](https://github.com/StackExchange/StackExchange.Redis/blob/main/docs/ServerMaintenanceEvent.md)

This PR allows you to subscribe `ServerMaintenanceEvent` via `IConnectionEventHandler`.