### PR TITLE
Enabled the connection to be released.

### DIFF
--- a/src/CloudStructures/RedisConnection.cs
+++ b/src/CloudStructures/RedisConnection.cs
@@ -166,6 +166,9 @@ public sealed class RedisConnection :
     private ConnectionMultiplexer? _connection;
     #endregion
 
+    /// <summary>
+    /// 
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public void ReleaseConnection()
     {
@@ -193,8 +196,7 @@ public sealed class RedisConnection :
     private bool _disposed;
 
     /// <inheritdoc />
-    [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public void Dispose()
+    void IDisposable.Dispose()
     {
         this._disposed = true;
         this.ReleaseConnection();

--- a/src/CloudStructures/RedisConnection.cs
+++ b/src/CloudStructures/RedisConnection.cs
@@ -134,12 +134,6 @@ public sealed class RedisConnection :
 
         lock (this._gate)
         {
-            this._connection = CreateConnectionCore();
-            return this._connection;
-        }
-
-        ConnectionMultiplexer CreateConnectionCore()
-        {
             ConnectionMultiplexer? connection = null;
 
             try
@@ -164,13 +158,15 @@ public sealed class RedisConnection :
                     connection.ServerMaintenanceEvent += this.OnServerMaintenanceEvent;
                 }
 
-                return connection;
+                this._connection = connection;
             }
             catch
             {
                 connection?.Dispose();
                 throw;
             }
+
+            return this._connection;
         }
     }
 

--- a/src/CloudStructures/RedisConnection.cs
+++ b/src/CloudStructures/RedisConnection.cs
@@ -206,10 +206,14 @@ public sealed class RedisConnection :
 
     private void CheckDisposed()
     {
+#if NET7_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(this._disposed, this);
+#else
         if (this._disposed)
         {
             throw new ObjectDisposedException(this.GetType().FullName);
         }
+#endif
     }
 
     private void OnConfigurationChanged(object? sender, EndPointEventArgs e)

--- a/src/CloudStructures/RedisConnection.cs
+++ b/src/CloudStructures/RedisConnection.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -47,6 +47,9 @@ public sealed class RedisConnection :
     /// <summary>
     /// Gets an interactive connection to a database inside redis.
     /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    /// This object has already been disposed.
+    /// </exception>
     internal IDatabaseAsync Database
     {
         get
@@ -63,6 +66,9 @@ public sealed class RedisConnection :
     /// <summary>
     /// Gets a transaction.
     /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    /// This object has already been disposed.
+    /// </exception>
     internal ITransaction Transaction
     {
         get
@@ -77,6 +83,9 @@ public sealed class RedisConnection :
     /// <summary>
     /// Gets target servers.
     /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    /// This object has already been disposed.
+    /// </exception>
     internal IServer[] Servers
     {
         get
@@ -116,6 +125,9 @@ public sealed class RedisConnection :
     /// Gets underlying connection.
     /// </summary>
     /// <returns></returns>
+    /// <exception cref="ObjectDisposedException">
+    /// This object has already been disposed.
+    /// </exception>
     public ConnectionMultiplexer GetConnection()
     {
         this.CheckDisposed();
@@ -167,8 +179,14 @@ public sealed class RedisConnection :
     #endregion
 
     /// <summary>
-    /// 
+    /// The internal connection is destroyed without destroying this object.
     /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    /// This object has already been disposed.
+    /// </exception>
+    /// <remarks>
+    /// The internal connection will be recreated the next time the <see cref="GetConnection"/> method is called.
+    /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public void ReleaseConnection()
     {

--- a/src/CloudStructures/RedisConnection.cs
+++ b/src/CloudStructures/RedisConnection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -172,6 +172,8 @@ public sealed class RedisConnection :
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public void ReleaseConnection()
     {
+        this.CheckDisposed();
+
         lock (this._gate)
         {
             if (this._connection is not { } connection)


### PR DESCRIPTION
I implemented `IDisposable` in `RedisConnection` and added a `ReleaseConnection` method so that the internal `ConnectionMultiplexer` could be released.

For example, if using Redis on [Amazon Elasticache](https://aws.amazon.com/elasticache/), StackExchange.Redis will not detect that a node has failed over and will not automatically connect to the new node.
Therefore, it is necessary to destroy and recreate the `ConnectionMultiplexer` instance, but `RedisConnection` did not support this functionality.

This patch makes it possible.

see: https://tech.guitarrapc.com/entry/2025/01/25/235900
see: https://github.com/StackExchange/StackExchange.Redis/issues/1874