### PR TITLE
Enable artifacts output

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,7 @@
         <LangVersion>14.0</LangVersion>
         <Nullable>enable</Nullable>
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+        <UseArtifactsOutput>true</UseArtifactsOutput>
     </PropertyGroup>
     
 </Project>


### PR DESCRIPTION
This pull request introduces a small configuration change to the build process by enabling the use of artifacts output in the project settings.

* Enabled the `UseArtifactsOutput` property in `src/Directory.Build.props` to direct build outputs to the artifacts directory, which helps with build output organization and consistency.