### PR TITLE
Fix Nuget.props

### DIFF
--- a/src/libs/NuGet.props
+++ b/src/libs/NuGet.props
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <IsPackable>true</IsPackable>
         <Version>3.4.1.0</Version>
-        <PackageProjectUrl>https://github.com/neuecc/CloudStructures</PackageProjectUrl>
+        <PackageProjectUrl>https://github.com/xin9le/CloudStructures</PackageProjectUrl>
         <PackageTags>Redis, Redis Client, O/R Mapping</PackageTags>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/libs/NuGet.props
+++ b/src/libs/NuGet.props
@@ -4,7 +4,7 @@
         <IsPackable>true</IsPackable>
         <Version>3.4.1.0</Version>
         <PackageProjectUrl>https://github.com/xin9le/CloudStructures</PackageProjectUrl>
-        <PackageTags>Redis, Redis Client, O/R Mapping</PackageTags>
+        <PackageTags>Redis, O/R Mapping</PackageTags>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>

--- a/src/libs/NuGet.props
+++ b/src/libs/NuGet.props
@@ -11,7 +11,7 @@
         <RepositoryType>Git</RepositoryType>
         <Company />
         <Authors>neuecc, xin9le</Authors>
-        <Copyright>Copyright© neuecc, xin9le</Copyright>
+        <Copyright>Copyright© $(Authors)</Copyright>
         <PackageReleaseNotes></PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
This pull request updates NuGet package metadata in `src/libs/NuGet.props` to reflect the current project ownership and improve consistency.

Metadata updates:

* Changed the `PackageProjectUrl` to point to the new GitHub repository under the `xin9le` organization.
* Updated the `PackageTags` to remove the redundant "Redis Client" tag.
* Modified the `Copyright` property to dynamically use the `Authors` value.